### PR TITLE
Fix NativeModules import

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var NativeModules = require('NativeModules');
+var NativeModules = require('react-native').NativeModules;
 var RNKeychainManager = NativeModules.RNKeychainManager;
 
 var Keychain = {


### PR DESCRIPTION
When I upgraded to react native 0.7.1 from 0.6.0 I started getting hit by the following warnings:

```
[14:40:52] <END>   transform (321ms)
Unable to resolve module NativeModules from ./node_modules/react-native-keychain/index.ios.js
Unable to resolve module NativeModules from ./node_modules/react-native-keychain/index.ios.js
Unable to resolve module NativeModules from ./node_modules/react-native-keychain/index.ios.js
Unable to resolve module NativeModules from ./node_modules/react-native-keychain/index.ios.js
[14:46:28] <START> find dependencies
```

Using this method of requiring NativeModules fixes it. Thanks!