### PR TITLE
Fix accessible

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -94,7 +94,7 @@ CFStringRef accessibleValue(NSString *jsAccessibleKey)
             
         }
     }
-    return kSecAttrAccessibleAfterFirstUnlock
+    return kSecAttrAccessibleAfterFirstUnlock;
 }
 
 RCT_EXPORT_METHOD(setGenericPasswordForService:(NSString*)service withUsername:(NSString*)username withPassword:(NSString*)password withAccessible:(NSString *)accessible resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(setGenericPasswordForService:(NSString*)service withUsername:(
 
   // Create dictionary of parameters to add
   NSData* passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
-  dict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassGenericPassword), kSecClass, service, kSecAttrService, passwordData, kSecValueData, username, kSecAttrAccount, nil];
+  dict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassGenericPassword), kSecClass, kSecAttrAccessibleAfterFirstUnlock, kSecAttrAccessible, service, kSecAttrService, passwordData, kSecValueData, username, kSecAttrAccount, nil];
 
   // Try to save to keychain
   osStatus = SecItemAdd((__bridge CFDictionaryRef) dict, NULL);
@@ -165,7 +165,7 @@ RCT_EXPORT_METHOD(setInternetCredentialsForServer:(NSString*)server withUsername
 
   // Create dictionary of parameters to add
   NSData* passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
-  dict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassInternetPassword), kSecClass, server, kSecAttrServer, passwordData, kSecValueData, username, kSecAttrAccount, nil];
+  dict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassInternetPassword), kSecClass, kSecAttrAccessibleAfterFirstUnlock, kSecAttrAccessible, server, kSecAttrServer, passwordData, kSecValueData, username, kSecAttrAccount, nil];
 
   // Try to save to keychain
   osStatus = SecItemAdd((__bridge CFDictionaryRef) dict, NULL);

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -43,7 +43,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setGenericPasswordForService(String service, String username, String password, Promise promise) {
+    public void setGenericPasswordForService(String service, String username, String password, String accessible, Promise promise) {
         if (!crypto.isAvailable()) {
             Log.e(KEYCHAIN_MODULE, "Crypto is missing");
             promise.reject("KeychainModule: crypto is missing");
@@ -134,8 +134,8 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setInternetCredentialsForServer(@NonNull String server, String username, String password, Promise promise) {
-        setGenericPasswordForService(server, username, password, promise);
+    public void setInternetCredentialsForServer(@NonNull String server, String username, String password, String accessible, Promise promise) {
+        setGenericPasswordForService(server, username, password, accessible, promise);
     }
 
     @ReactMethod

--- a/index.js
+++ b/index.js
@@ -10,18 +10,6 @@ type SecAccessible =
   | 'AccessibleAfterFirstUnlockThisDeviceOnly'
   | 'AccessibleAlwaysThisDeviceOnly'
 
-function convertError(err) {
-  if (!err) {
-    return null;
-  }
-  if (Platform.OS === 'android') {
-    return new Error(err);
-  }
-  var out = new Error(err.message);
-  out.key = err.key;
-  return out;
-}
-
 /**
  * Saves the `username` and `password` combination for `server`.
  * @param {string} server URL to server.

--- a/index.js
+++ b/index.js
@@ -1,19 +1,42 @@
 import { NativeModules, Platform } from 'react-native';
 const { RNKeychainManager } = NativeModules;
 
+type SecAccessible =
+  | 'AccessibleWhenUnlocked'
+  | 'AccessibleAfterFirstUnlock'
+  | 'AccessibleAlways'
+  | 'AccessibleWhenPasscodeSetThisDeviceOnly'
+  | 'AccessibleWhenUnlockedThisDeviceOnly'
+  | 'AccessibleAfterFirstUnlockThisDeviceOnly'
+  | 'AccessibleAlwaysThisDeviceOnly'
+
+function convertError(err) {
+  if (!err) {
+    return null;
+  }
+  if (Platform.OS === 'android') {
+    return new Error(err);
+  }
+  var out = new Error(err.message);
+  out.key = err.key;
+  return out;
+}
+
 /**
  * Saves the `username` and `password` combination for `server`.
  * @param {string} server URL to server.
  * @param {string} username Associated username or e-mail to be saved.
  * @param {string} password Associated password to be saved.
+ * @param {string} accessible (iOS only) kSecAccessibleKey
  * @return {Promise} Resolves to `true` when successful
  */
 export function setInternetCredentials(
   server: string,
   username: string,
-  password: string
+  password: string,
+  accessible?: SecAccessible
 ): Promise {
-  return RNKeychainManager.setInternetCredentialsForServer(server, username, password);
+  return RNKeychainManager.setInternetCredentialsForServer(server, username, password, accessible);
 }
 
 /**
@@ -43,14 +66,16 @@ export function resetInternetCredentials(
  * @param {string} username Associated username or e-mail to be saved.
  * @param {string} password Associated password to be saved.
  * @param {string} service Reverse domain name qualifier for the service, defaults to `bundleId`.
+ * @param {string} accessible (iOS only) kSecAccessibleKey
  * @return {Promise} Resolves to `true` when successful
  */
 export function setGenericPassword(
   username: string,
   password: string,
   service?: string
+  accessible?: SecAccessible
 ): Promise {
-  return RNKeychainManager.setGenericPasswordForService(service, username, password);
+  return RNKeychainManager.setGenericPasswordForService(service, username, password, accessible);
 }
 
 /**


### PR DESCRIPTION
Every now I then I get reports of `Keychain item not found` for users that should have a keychain item.

I suspect that the default is not good enough and have always previously set `AccessibleAfterFirstUnlock`.

This changes the default so that the keychain item is available when the app is in the background, or even as I suspect, in a transition between background or locked state.