### PR TITLE
Update TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "typescript": {
     "definition": "typings/react-native-keychain.d.ts"
   },
+  "types": "typings/react-native-keychain.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/oblador/react-native-keychain.git"

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -29,11 +29,15 @@ declare module 'react-native-keychain' {
         username: string,
         password: string,
         service?: string
-    ): Promise<void>;
+    ): Promise<boolean>;
 
     function getGenericPassword(
         service?: string
-    ): Promise<void>;
+    ): Promise<boolean | {service: string, username: string, password: string}>;
+
+    function resetGenericPassword(
+        service?: string
+    ): Promise<boolean>
 
     function requestSharedWebCredentials (
     ): Promise<SharedWebCredentials>;


### PR DESCRIPTION
This pull request updates the package.json to use the "types" attribute to declare where the type definition file is located. I am not sure if the "typescript" attribute was an older method of declaring this but I am using TypeScript 2.2.1 and the current type definitions are not found until I use the "types" attribute. See: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html for clarification.

I also updated some of the type definitions to have more accurate promise values.