### PR TITLE
Add react-native-keychain on tvOS 

### DIFF
--- a/RNKeychain.podspec
+++ b/RNKeychain.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.homepage       = "https://github.com/oblador/react-native-keychain"
   s.license        = "MIT"
   s.author         = { "Joel Arvidsson" => "joel@oblador.se" }
-  s.platform       = :ios, "7.0"
+  s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.0'
   s.source         = { :git => "https://github.com/oblador/react-native-keychain.git", :tag => "v#{s.version}" }
   s.source_files   = 'RNKeychainManager/**/*.{h,m}'
   s.preserve_paths = "**/*.js"

--- a/RNKeychain.xcodeproj/project.pbxproj
+++ b/RNKeychain.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		5D82368F1B0CE3CB005A9EF3 /* RNKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D82368C1B0CE2A6005A9EF3 /* RNKeychainManager.m */; };
 		5D8236911B0CE3D6005A9EF3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D8236901B0CE3D6005A9EF3 /* Security.framework */; };
+		6478986A1F38BF9D00DA1C12 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 647898691F38BF9D00DA1C12 /* Security.framework */; };
+		6478986B1F38BFA100DA1C12 /* RNKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D82368C1B0CE2A6005A9EF3 /* RNKeychainManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -22,6 +24,15 @@
 			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6478985D1F38BF9100DA1C12 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +40,8 @@
 		5D82368B1B0CE2A6005A9EF3 /* RNKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNKeychainManager.h; sourceTree = "<group>"; };
 		5D82368C1B0CE2A6005A9EF3 /* RNKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNKeychainManager.m; sourceTree = "<group>"; };
 		5D8236901B0CE3D6005A9EF3 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		6478985F1F38BF9100DA1C12 /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		647898691F38BF9D00DA1C12 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.2.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,6 +50,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D8236911B0CE3D6005A9EF3 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6478985C1F38BF9100DA1C12 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6478986A1F38BF9D00DA1C12 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -49,6 +70,7 @@
 				5D8236901B0CE3D6005A9EF3 /* Security.framework */,
 				5D82368A1B0CE2A6005A9EF3 /* RNKeychainManager */,
 				5D8236701B0CE05B005A9EF3 /* Products */,
+				647898681F38BF9C00DA1C12 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 			wrapsLines = 0;
@@ -57,6 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				5D82366F1B0CE05B005A9EF3 /* libRNKeychain.a */,
+				6478985F1F38BF9100DA1C12 /* libRNKeychain.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -68,6 +91,14 @@
 				5D82368C1B0CE2A6005A9EF3 /* RNKeychainManager.m */,
 			);
 			path = RNKeychainManager;
+			sourceTree = "<group>";
+		};
+		647898681F38BF9C00DA1C12 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				647898691F38BF9D00DA1C12 /* Security.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -90,6 +121,23 @@
 			productReference = 5D82366F1B0CE05B005A9EF3 /* libRNKeychain.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		6478985E1F38BF9100DA1C12 /* RNKeychain-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 647898671F38BF9100DA1C12 /* Build configuration list for PBXNativeTarget "RNKeychain-tvOS" */;
+			buildPhases = (
+				6478985B1F38BF9100DA1C12 /* Sources */,
+				6478985C1F38BF9100DA1C12 /* Frameworks */,
+				6478985D1F38BF9100DA1C12 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RNKeychain-tvOS";
+			productName = "RNKeychain-tvOS";
+			productReference = 6478985F1F38BF9100DA1C12 /* libRNKeychain.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -101,6 +149,10 @@
 				TargetAttributes = {
 					5D82366E1B0CE05B005A9EF3 = {
 						CreatedOnToolsVersion = 6.3.1;
+					};
+					6478985E1F38BF9100DA1C12 = {
+						CreatedOnToolsVersion = 8.3.3;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -117,6 +169,7 @@
 			projectRoot = "";
 			targets = (
 				5D82366E1B0CE05B005A9EF3 /* RNKeychain */,
+				6478985E1F38BF9100DA1C12 /* RNKeychain-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -127,6 +180,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D82368F1B0CE3CB005A9EF3 /* RNKeychainManager.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6478985B1F38BF9100DA1C12 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6478986B1F38BFA100DA1C12 /* RNKeychainManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -243,6 +304,40 @@
 			};
 			name = Release;
 		};
+		647898651F38BF9100DA1C12 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Debug;
+		};
+		647898661F38BF9100DA1C12 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNKeychain;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -263,6 +358,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		647898671F38BF9100DA1C12 /* Build configuration list for PBXNativeTarget "RNKeychain-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				647898651F38BF9100DA1C12 /* Debug */,
+				647898661F38BF9100DA1C12 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/RNKeychain.xcodeproj/project.pbxproj
+++ b/RNKeychain.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		5D8236661B0CE05B005A9EF3 = {
 			isa = PBXGroup;
 			children = (
-				5D8236901B0CE3D6005A9EF3 /* Security.framework */,
 				5D82368A1B0CE2A6005A9EF3 /* RNKeychainManager */,
 				5D8236701B0CE05B005A9EF3 /* Products */,
 				647898681F38BF9C00DA1C12 /* Frameworks */,
@@ -96,6 +95,7 @@
 		647898681F38BF9C00DA1C12 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5D8236901B0CE3D6005A9EF3 /* Security.framework */,
 				647898691F38BF9D00DA1C12 /* Security.framework */,
 			);
 			name = Frameworks;
@@ -366,6 +366,7 @@
 				647898661F38BF9100DA1C12 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -288,46 +288,46 @@ RCT_EXPORT_METHOD(resetInternetCredentialsForServer:(NSString *)server withOptio
 #if TARGET_OS_IOS
 RCT_EXPORT_METHOD(requestSharedWebCredentials:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
-        if (error != NULL) {
-            NSError *nsError = (__bridge NSError *)error;
-            return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
-        }
-        
-        if (CFArrayGetCount(credentials) > 0) {
-            
-            CFDictionaryRef credentialDict = CFArrayGetValueAtIndex(credentials, 0);
-            NSString *server = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrServer);
-            NSString *username = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrAccount);
-            NSString *password = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecSharedPassword);
-            
-            return resolve(@{
-                             @"server": server,
-                             @"username": username,
-                             @"password": password
-                             });
-        }
-        return resolve(@(NO));
-    });
+  SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
+    if (error != NULL) {
+      NSError *nsError = (__bridge NSError *)error;
+      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
+    }
+
+    if (CFArrayGetCount(credentials) > 0) {
+
+      CFDictionaryRef credentialDict = CFArrayGetValueAtIndex(credentials, 0);
+      NSString *server = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrServer);
+      NSString *username = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrAccount);
+      NSString *password = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecSharedPassword);
+
+      return resolve(@{
+        @"server": server,
+        @"username": username,
+        @"password": password
+      });
+    }
+    return resolve(@(NO));
+  });
 }
 
 
 RCT_EXPORT_METHOD(setSharedWebCredentialsForServer:(NSString *)server withUsername:(NSString *)username withPassword:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    SecAddSharedWebCredential(
-                              (__bridge CFStringRef)server,
-                              (__bridge CFStringRef)username,
-                              (__bridge CFStringRef)password,
-                              ^(CFErrorRef error)
-                              {
-                                  
-                                  if (error != NULL) {
-                                      NSError *nsError = (__bridge NSError *)error;
-                                      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
-                                  }
-                                  
-                                  resolve(@(YES));
-                              });
+  SecAddSharedWebCredential(
+    (__bridge CFStringRef)server,
+    (__bridge CFStringRef)username,
+    (__bridge CFStringRef)password,
+    ^(CFErrorRef error)
+  {
+
+    if (error != NULL) {
+      NSError *nsError = (__bridge NSError *)error;
+      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
+    }
+
+    resolve(@(YES));
+  });
 }
 #endif
 

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -285,48 +285,50 @@ RCT_EXPORT_METHOD(resetInternetCredentialsForServer:(NSString *)server withOptio
 
 }
 
+#if TARGET_OS_IOS
 RCT_EXPORT_METHOD(requestSharedWebCredentials:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
-    if (error != NULL) {
-      NSError *nsError = (__bridge NSError *)error;
-      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
-    }
-
-    if (CFArrayGetCount(credentials) > 0) {
-
-      CFDictionaryRef credentialDict = CFArrayGetValueAtIndex(credentials, 0);
-      NSString *server = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrServer);
-      NSString *username = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrAccount);
-      NSString *password = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecSharedPassword);
-
-      return resolve(@{
-        @"server": server,
-        @"username": username,
-        @"password": password
-      });
-    }
-    return resolve(@(NO));
-  });
+    SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
+        if (error != NULL) {
+            NSError *nsError = (__bridge NSError *)error;
+            return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
+        }
+        
+        if (CFArrayGetCount(credentials) > 0) {
+            
+            CFDictionaryRef credentialDict = CFArrayGetValueAtIndex(credentials, 0);
+            NSString *server = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrServer);
+            NSString *username = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecAttrAccount);
+            NSString *password = (__bridge NSString *)CFDictionaryGetValue(credentialDict, kSecSharedPassword);
+            
+            return resolve(@{
+                             @"server": server,
+                             @"username": username,
+                             @"password": password
+                             });
+        }
+        return resolve(@(NO));
+    });
 }
 
 
 RCT_EXPORT_METHOD(setSharedWebCredentialsForServer:(NSString *)server withUsername:(NSString *)username withPassword:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  SecAddSharedWebCredential(
-    (__bridge CFStringRef)server,
-    (__bridge CFStringRef)username,
-    (__bridge CFStringRef)password,
-    ^(CFErrorRef error)
-  {
-
-    if (error != NULL) {
-      NSError *nsError = (__bridge NSError *)error;
-      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
-    }
-
-    resolve(@(YES));
-  });
+    SecAddSharedWebCredential(
+                              (__bridge CFStringRef)server,
+                              (__bridge CFStringRef)username,
+                              (__bridge CFStringRef)password,
+                              ^(CFErrorRef error)
+                              {
+                                  
+                                  if (error != NULL) {
+                                      NSError *nsError = (__bridge NSError *)error;
+                                      return reject([NSString stringWithFormat:@"%li", (long)nsError.code], nsError.description, nil);
+                                  }
+                                  
+                                  resolve(@(YES));
+                              });
 }
+#endif
 
 @end


### PR DESCRIPTION
Now we can use react native keychain on tvOS, I have test it and I use it in my project and it works perfectly

![tmp](https://user-images.githubusercontent.com/7658664/29062564-763b2042-7c22-11e7-97a4-3a4adc02c21e.jpeg)

I've disable: 
- setSharedWebCredentialsForServer
- requestSharedWebCredentials

Because they are only for [iOS](https://developer.apple.com/documentation/security/shared_web_credentials)