### PR TITLE
Upgraded Gradle build tools version to 26.0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.1.3'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  buildToolsVersion "26.0.2"
 
   defaultConfig {
     minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Tue Nov 07 13:35:23 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
When I was importing this library into my project, I noticed that the Gradle version and the build tools version on Android were too low to work with my project. I updated the version number to be compatible with Android Studio 2.3.3, and I have confirmed that this works with Android Studio 3.0. Android Studio 2.3.3 and 3.0 both require a minimum tools version of 25.0.0. 

I haven't seen any bugs in the library due to this version bump, so I thought I'd submit a pull request. Please let me know if there's any reason to keep the build tools version number at the current version.