### PR TITLE
improve consistency and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Both `setGenericPassword` and `setInternetCredentials` are limited to strings on
 
 ### `setGenericPassword(username, password, [{ accessControl, accessible, accessGroup, service }])`
 
-Will store the username/password combination in the secure storage. Resolves to `{ username, password }` if an entry exists or `false` if it doesn't.
+Will store the username/password combination in the secure storage. Resolves to `true` or rejects in case of an error.
 
 ### `getGenericPassword([{ authenticationPrompt, service }])`
 
-Will retreive the username/password combination from the secure storage. It will reject only if an unexpected error is encountered like lacking entitlements or permission.
+Will retreive the username/password combination from the secure storage. Resolves to `{ username, password }` if an entry exists or `false` if it doesn't. It will reject only if an unexpected error is encountered like lacking entitlements or permission.
 
 ### `resetGenericPassword([{ service }])`
 

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -68,7 +68,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
             EncryptionResult result = currentCipherStorage.encrypt(service, username, password);
             prefsStorage.storeEncryptedEntry(service, result);
 
-            promise.resolve("KeychainModule saved the data");
+            promise.resolve(true);
         } catch (EmptyParameterException e) {
             Log.e(KEYCHAIN_MODULE, e.getMessage());
             promise.reject(E_EMPTY_PARAMETERS, e);


### PR DESCRIPTION
when inserting keychain entry, ios resolves with true, as seen [here](https://github.com/oblador/react-native-keychain/blob/master/RNKeychainManager/RNKeychainManager.m#L220); this makes sure the behavior is the same on android, plus fixing docs