### PR TITLE
Add options param to getInternetCredentials typing

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -34,7 +34,8 @@ declare module 'react-native-keychain' {
     ): Promise<void>;
 
     function getInternetCredentials(
-        server: string
+        server: string,
+        options?: Options
     ): Promise<UserCredentials>;
 
     function resetInternetCredentials(


### PR DESCRIPTION
I think `getInternetCredentials` should have an options param, but the Typescript typings file doesn't have it.