### PR TITLE
Catch uncaught exceptions to prevent crash

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -88,6 +88,8 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             throw new CryptoFailedException("Could not encrypt data for service " + service, e);
         } catch (KeyStoreException | KeyStoreAccessException e) {
             throw new CryptoFailedException("Could not access Keystore for service " + service, e);
+        } catch (Exception e) {
+            throw new CryptoFailedException("Unknown error: " + e.getMessage(), e);
         }
     }
 
@@ -108,6 +110,8 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             throw new CryptoFailedException("Could not get key from Keystore", e);
         } catch (KeyStoreAccessException e) {
             throw new CryptoFailedException("Could not access Keystore", e);
+        } catch (Exception e) {
+            throw new CryptoFailedException("Unknown error: " + e.getMessage(), e);
         }
     }
 
@@ -123,6 +127,8 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             }
         } catch (KeyStoreException e) {
             throw new KeyStoreAccessException("Failed to access Keystore", e);
+        } catch (Exception e) {
+            throw new KeyStoreAccessException("Unknown error " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
`NullPointerException` thrown on some Huawei devices is crashing entire app.
Handle all exceptions and rethrow them as caught exceptions.

This is an attempt to prevent issue described in https://github.com/oblador/react-native-keychain/issues/115.