### PR TITLE
android: use getReactApplicationContext instead of getCurrentActivity

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -203,7 +203,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     }
 
     private boolean isFingerprintAuthAvailable() {
-        return DeviceAvailability.isFingerprintAuthAvailable(getCurrentActivity());
+        return DeviceAvailability.isFingerprintAuthAvailable(getReactApplicationContext());
     }
 
     @NonNull


### PR DESCRIPTION
`getCurrentActivity` might return `null`, leading to a null pointer exception. Replacing it by `getReactApplicationContext` should work more robustly.