### PR TITLE
extract a function, add null checks

### DIFF
--- a/android/src/main/java/com/oblador/keychain/DeviceAvailability.java
+++ b/android/src/main/java/com/oblador/keychain/DeviceAvailability.java
@@ -10,15 +10,15 @@ public class DeviceAvailability {
         if (android.os.Build.VERSION.SDK_INT >= 23) {
             FingerprintManager fingerprintManager =
                 (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
-            return fingerprintManager.isHardwareDetected() &&
+            return fingerprintManager != null && fingerprintManager.isHardwareDetected() &&
                 fingerprintManager.hasEnrolledFingerprints();
         }
         return false;
     }
 
-    public static boolean isSecure(Context context) {
+    public static boolean isDeviceSecure(Context context) {
         KeyguardManager keyguardManager =
                 (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
-        return android.os.Build.VERSION.SDK_INT >= 23 && keyguardManager.isDeviceSecure();
+        return Build.VERSION.SDK_INT >= 23 && keyguardManager != null && keyguardManager.isDeviceSecure();
     }
 }

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -61,7 +61,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             KeyStore keyStore = getKeyStoreAndLoad();
 
             if (!keyStore.containsAlias(service)) {
-                addAliasToKeystore(service);
+                generateKeyAndStoreUnderAlias(service);
             }
 
             Key key = keyStore.getKey(service, null);
@@ -79,7 +79,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         }
     }
 
-    private void addAliasToKeystore(@NonNull String service) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+    private void generateKeyAndStoreUnderAlias(@NonNull String service) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         AlgorithmParameterSpec spec = new KeyGenParameterSpec.Builder(
                 service,
                 KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -29,6 +29,7 @@ import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.spec.IvParameterSpec;
 
+@TargetApi(Build.VERSION_CODES.M)
 public class CipherStorageKeystoreAESCBC implements CipherStorage {
     public static final String CIPHER_STORAGE_NAME = "KeystoreAESCBC";
     public static final String DEFAULT_SERVICE = "RN_KEYCHAIN_DEFAULT_ALIAS";
@@ -52,7 +53,6 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         return Build.VERSION_CODES.M;
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
     @Override
     public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password) throws CryptoFailedException {
         service = getDefaultServiceIfEmpty(service);
@@ -61,21 +61,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             KeyStore keyStore = getKeyStoreAndLoad();
 
             if (!keyStore.containsAlias(service)) {
-                AlgorithmParameterSpec spec;
-                spec = new KeyGenParameterSpec.Builder(
-                        service,
-                        KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                        .setBlockModes(ENCRYPTION_BLOCK_MODE)
-                        .setEncryptionPaddings(ENCRYPTION_PADDING)
-                        .setRandomizedEncryptionRequired(true)
-                        //.setUserAuthenticationRequired(true) // Will throw InvalidAlgorithmParameterException if there is no fingerprint enrolled on the device
-                        .setKeySize(ENCRYPTION_KEY_SIZE)
-                        .build();
-
-                KeyGenerator generator = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM, KEYSTORE_TYPE);
-                generator.init(spec);
-
-                generator.generateKey();
+                addAliasToKeystore(service);
             }
 
             Key key = keyStore.getKey(service, null);
@@ -91,6 +77,23 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         } catch (Exception e) {
             throw new CryptoFailedException("Unknown error: " + e.getMessage(), e);
         }
+    }
+
+    private void addAliasToKeystore(@NonNull String service) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+        AlgorithmParameterSpec spec = new KeyGenParameterSpec.Builder(
+                service,
+                KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+                .setBlockModes(ENCRYPTION_BLOCK_MODE)
+                .setEncryptionPaddings(ENCRYPTION_PADDING)
+                .setRandomizedEncryptionRequired(true)
+                //.setUserAuthenticationRequired(true) // Will throw InvalidAlgorithmParameterException if there is no fingerprint enrolled on the device
+                .setKeySize(ENCRYPTION_KEY_SIZE)
+                .build();
+
+        KeyGenerator generator = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM, KEYSTORE_TYPE);
+        generator.init(spec);
+
+        generator.generateKey();
     }
 
     @Override


### PR DESCRIPTION
this is a small diff

- as for the null checks - I locally upgraded android gradle plugin and after the upgrade I started getting null warnings. 
- I renamed `isSecure` to `isDeviceSecure` since it's more descriptive. The function is not used anywhere though so we may as well remove it
- added `generateKeyAndStoreUnderAlias ` function. Its body was previously in an if block and it wasn't very clear to me what the block was doing (the `generator.generateKey()` not only returns a `SecterKey` instance, it does other things too, including adding the Alias to Keystore)