### PR TITLE
[Android] Implement security level guarantees.

### DIFF
--- a/KeychainExample/App.js
+++ b/KeychainExample/App.js
@@ -128,6 +128,7 @@ export default class KeychainExample extends Component {
                 <Text style={styles.buttonText}>Save</Text>
               </View>
             </TouchableHighlight>
+
             <TouchableHighlight
               onPress={() => this.load()}
               style={styles.button}
@@ -136,12 +137,29 @@ export default class KeychainExample extends Component {
                 <Text style={styles.buttonText}>Load</Text>
               </View>
             </TouchableHighlight>
+
             <TouchableHighlight
               onPress={() => this.reset()}
               style={styles.button}
             >
               <View style={styles.reset}>
                 <Text style={styles.buttonText}>Reset</Text>
+              </View>
+            </TouchableHighlight>
+
+            <TouchableHighlight
+              onPress={async() => {
+                if (Platform.OS !== 'android') {
+                  alert('android-only feature');
+                  return;
+                }
+                const level = await Keychain.getSecurityLevel();
+                alert(level)
+              }}
+              style={styles.button}
+            >
+              <View style={styles.load}>
+                <Text style={styles.buttonText}>Get security level</Text>
               </View>
             </TouchableHighlight>
           </View>

--- a/KeychainExample/android/build.gradle
+++ b/KeychainExample/android/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "27.0.3"
+        buildToolsVersion = "28.0.0"
         minSdkVersion = 16
-        compileSdkVersion = 27
+        compileSdkVersion = 28
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
     }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See `KeychainExample` for fully working project example.
 
 Both `setGenericPassword` and `setInternetCredentials` are limited to strings only, so if you need to store objects etc, please use `JSON.stringify`/`JSON.parse` when you store/access it.
 
-### `setGenericPassword(username, password, [{ accessControl, accessible, accessGroup, service }])`
+### `setGenericPassword(username, password, securityLevel, [{ accessControl, accessible, accessGroup, service }])`
 
 Will store the username/password combination in the secure storage. Resolves to `true` or rejects in case of an error.
 
@@ -57,7 +57,7 @@ Will retreive the username/password combination from the secure storage. Resolve
 
 Will remove the username/password combination from the secure storage.
 
-### `setInternetCredentials(server, username, password, [{ accessControl, accessible, accessGroup }])`
+### `setInternetCredentials(server, username, password, securityLevel, [{ accessControl, accessible, accessGroup }])`
 
 Will store the server/username/password combination in the secure storage.
 
@@ -88,6 +88,18 @@ Inquire if the type of local authentication policy is supported on this device w
 ### `getSupportedBiometryType()`
 
 Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
+
+### `getSecurityLevel()`
+
+Get security level that is supported on the current device with the current OS.
+
+### Security Levels (Android only)
+
+If set, `securityLevel` parameter specifies minimum security level that the encryption key storage should guarantee for storing credentials to succeed.
+
+* `ANY` - no security guarantees needed (default value); Credentials can be stored in FB Secure Storage;
+* `SECURE_SOFTWARE` - requires for the key to be stored in the Android Keystore, separate from the encrypted data;
+* `SECURE_HARDWARE` - requires for the key to be stored on a secure hardware (Trusted Execution Environment or Secure Environment). Read [this article](https://developer.android.com/training/articles/keystore#ExtractionPrevention) for more information.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See `KeychainExample` for fully working project example.
 
 Both `setGenericPassword` and `setInternetCredentials` are limited to strings only, so if you need to store objects etc, please use `JSON.stringify`/`JSON.parse` when you store/access it.
 
-### `setGenericPassword(username, password, securityLevel, [{ accessControl, accessible, accessGroup, service }])`
+### `setGenericPassword(username, password, [{ accessControl, accessible, accessGroup, service, securityLevel }])`
 
 Will store the username/password combination in the secure storage. Resolves to `true` or rejects in case of an error.
 
@@ -57,7 +57,7 @@ Will retreive the username/password combination from the secure storage. Resolve
 
 Will remove the username/password combination from the secure storage.
 
-### `setInternetCredentials(server, username, password, securityLevel, [{ accessControl, accessible, accessGroup }])`
+### `setInternetCredentials(server, username, password, [{ accessControl, accessible, accessGroup, securityLevel }])`
 
 Will store the server/username/password combination in the secure storage.
 
@@ -89,7 +89,7 @@ Inquire if the type of local authentication policy is supported on this device w
 
 Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
 
-### `getSecurityLevel()`
+### `getSecurityLevel()` (Android only)
 
 Get security level that is supported on the current device with the current OS.
 

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -285,7 +285,7 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve rejec
 }
 #endif
 
-RCT_EXPORT_METHOD(setGenericPasswordForOptions:(NSDictionary *)options withUsername:(NSString *)username withPassword:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(setGenericPasswordForOptions:(NSDictionary *)options withUsername:(NSString *)username withPassword:(NSString *)password withSecurityLevel:(__unused NSString *)level resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSString *service = serviceValue(options);
   NSDictionary *attributes = attributes = @{
@@ -358,7 +358,7 @@ RCT_EXPORT_METHOD(resetGenericPasswordForOptions:(NSDictionary *)options resolve
   return resolve(@(YES));
 }
 
-RCT_EXPORT_METHOD(setInternetCredentialsForServer:(NSString *)server withUsername:(NSString*)username withPassword:(NSString*)password withOptions:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(setInternetCredentialsForServer:(NSString *)server withUsername:(NSString*)username withPassword:(NSString*)password withSecurityLevel:(__unused NSString *)level withOptions:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   [self deleteCredentialsForServer:server];
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
   defaultConfig {

--- a/android/src/main/java/com/oblador/keychain/SecurityLevel.java
+++ b/android/src/main/java/com/oblador/keychain/SecurityLevel.java
@@ -5,6 +5,10 @@ public enum SecurityLevel {
     SECURE_SOFTWARE,
     SECURE_HARDWARE; // Trusted Execution Environment or Secure Environment guarantees
 
+    public String jsName() {
+        return String.format("SECURITY_LEVEL_%s", this.name());
+    }
+
     public boolean satisfiesSafetyThreshold(SecurityLevel threshold) {
         return this.compareTo(threshold) >= 0;
     }

--- a/android/src/main/java/com/oblador/keychain/SecurityLevel.java
+++ b/android/src/main/java/com/oblador/keychain/SecurityLevel.java
@@ -1,0 +1,12 @@
+package com.oblador.keychain;
+
+public enum SecurityLevel {
+    ANY,
+    SECURE_SOFTWARE,
+    SECURE_HARDWARE; // Trusted Execution Environment or Secure Environment guarantees
+
+    public boolean satisfiesSafetyThreshold(SecurityLevel threshold) {
+        return this.compareTo(threshold) >= 0;
+    }
+}
+

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
@@ -2,6 +2,7 @@ package com.oblador.keychain.cipherStorage;
 
 import android.support.annotation.NonNull;
 
+import com.oblador.keychain.SecurityLevel;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
@@ -26,12 +27,19 @@ public interface CipherStorage {
     }
 
     class DecryptionResult extends CipherResult<String> {
-        public DecryptionResult(String username, String password) {
+      private SecurityLevel securityLevel;
+
+      public DecryptionResult(String username, String password, SecurityLevel level) {
             super(username, password);
+            securityLevel = level;
         }
+
+      public SecurityLevel getSecurityLevel() {
+        return securityLevel;
+      }
     }
 
-    EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password) throws CryptoFailedException;
+    EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level) throws CryptoFailedException;
 
     DecryptionResult decrypt(@NonNull String service, @NonNull byte[] username, @NonNull byte[] password) throws CryptoFailedException;
 
@@ -40,4 +48,8 @@ public interface CipherStorage {
     String getCipherStorageName();
 
     int getMinSupportedApiLevel();
+
+    SecurityLevel securityLevel();
+
+    boolean supportsSecureHardware();
 }

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
@@ -10,6 +10,7 @@ import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.Entity;
 import com.facebook.crypto.keychain.KeyChain;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.SecurityLevel;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 
 import java.nio.charset.Charset;
@@ -35,7 +36,22 @@ public class CipherStorageFacebookConceal implements CipherStorage {
     }
 
     @Override
-    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password) throws CryptoFailedException {
+    public SecurityLevel securityLevel() {
+        return SecurityLevel.ANY;
+    }
+
+    @Override
+    public boolean supportsSecureHardware() {
+        return false;
+    }
+
+    @Override
+    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level) throws CryptoFailedException {
+
+        if (!this.securityLevel().satisfiesSafetyThreshold(level)) {
+            throw new CryptoFailedException(String.format("Insufficient security level (wants %s; got %s)", level, this.securityLevel()));
+        }
+
         if (!crypto.isAvailable()) {
             throw new CryptoFailedException("Crypto is missing");
         }
@@ -66,7 +82,8 @@ public class CipherStorageFacebookConceal implements CipherStorage {
 
             return new DecryptionResult(
                     new String(decryptedUsername, Charset.forName("UTF-8")),
-                    new String(decryptedPassword, Charset.forName("UTF-8")));
+                    new String(decryptedPassword, Charset.forName("UTF-8")),
+                    SecurityLevel.ANY);
         } catch (Exception e) {
             throw new CryptoFailedException("Decryption failed for service " + service, e);
         }

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -3,9 +3,12 @@ package com.oblador.keychain.cipherStorage;
 import android.annotation.TargetApi;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
+import com.oblador.keychain.SecurityLevel;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
@@ -21,16 +24,20 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import android.security.keystore.StrongBoxUnavailableException;
 
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.IvParameterSpec;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class CipherStorageKeystoreAESCBC implements CipherStorage {
+    public static final String TAG = "KeystoreAESCBC";
     public static final String CIPHER_STORAGE_NAME = "KeystoreAESCBC";
     public static final String DEFAULT_SERVICE = "RN_KEYCHAIN_DEFAULT_ALIAS";
     public static final String KEYSTORE_TYPE = "AndroidKeyStore";
@@ -54,14 +61,39 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
     }
 
     @Override
-    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password) throws CryptoFailedException {
+    public SecurityLevel securityLevel() {
+        // it can guarantee security levels up to SECURE_HARDWARE/SE/StrongBox
+        return SecurityLevel.SECURE_HARDWARE;
+    }
+
+    @Override
+    public boolean supportsSecureHardware() {
+        final String testKeyAlias = "AndroidKeyStore#supportsSecureHardware";
+
+        try {
+            SecretKey key = tryGenerateRegularSecurityKey(testKeyAlias);
+            return validateKeySecurityLevel(SecurityLevel.SECURE_HARDWARE, key);
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | NoSuchProviderException e) {
+            return false;
+        } finally {
+            try {
+                removeKey(testKeyAlias);
+            } catch (KeyStoreAccessException e) {
+                Log.e(TAG, "Unable to remove temp key from keychain", e);
+            }
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @Override
+    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level) throws CryptoFailedException {
         service = getDefaultServiceIfEmpty(service);
 
         try {
             KeyStore keyStore = getKeyStoreAndLoad();
 
             if (!keyStore.containsAlias(service)) {
-                generateKeyAndStoreUnderAlias(service);
+                generateKeyAndStoreUnderAlias(service, level);
             }
 
             Key key = keyStore.getKey(service, null);
@@ -79,21 +111,36 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         }
     }
 
-    private void generateKeyAndStoreUnderAlias(@NonNull String service) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-        AlgorithmParameterSpec spec = new KeyGenParameterSpec.Builder(
-                service,
-                KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                .setBlockModes(ENCRYPTION_BLOCK_MODE)
-                .setEncryptionPaddings(ENCRYPTION_PADDING)
-                .setRandomizedEncryptionRequired(true)
-                //.setUserAuthenticationRequired(true) // Will throw InvalidAlgorithmParameterException if there is no fingerprint enrolled on the device
-                .setKeySize(ENCRYPTION_KEY_SIZE)
-                .build();
+    @TargetApi(Build.VERSION_CODES.M)
+    private boolean validateKeySecurityLevel(SecurityLevel level, SecretKey generatedKey) {
+        return getSecurityLevel(generatedKey).satisfiesSafetyThreshold(level);
+    }
 
-        KeyGenerator generator = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM, KEYSTORE_TYPE);
-        generator.init(spec);
+    @TargetApi(Build.VERSION_CODES.M)
+    private SecurityLevel getSecurityLevel(SecretKey key) {
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(key.getAlgorithm(), KEYSTORE_TYPE);
+            KeyInfo keyInfo;
+            keyInfo = (KeyInfo) factory.getKeySpec(key, KeyInfo.class);
+            return keyInfo.isInsideSecureHardware() ? SecurityLevel.SECURE_HARDWARE : SecurityLevel.SECURE_SOFTWARE;
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
+            return SecurityLevel.ANY;
+        }
+    }
 
-        generator.generateKey();
+    private void generateKeyAndStoreUnderAlias(@NonNull String service, SecurityLevel requiredLevel) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException, CryptoFailedException {
+        // Firstly, try to generate the key as safe as possible (strongbox).
+        // see https://developer.android.com/training/articles/keystore#HardwareSecurityModule
+        SecretKey secretKey = tryGenerateStrongBoxSecurityKey(service);
+        if (secretKey == null) {
+            // If that is not possible, we generate the key in a regular way
+            // (it still might be generated in hardware, but not in StrongBox)
+            secretKey = tryGenerateRegularSecurityKey(service);
+        }
+
+        if(!validateKeySecurityLevel(requiredLevel, secretKey)) {
+            throw new CryptoFailedException("Cannot generate keys with required security guarantees");
+        }
     }
 
     @Override
@@ -108,7 +155,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             String decryptedUsername = decryptBytes(key, username);
             String decryptedPassword = decryptBytes(key, password);
 
-            return new DecryptionResult(decryptedUsername, decryptedPassword);
+            return new DecryptionResult(decryptedUsername, decryptedPassword, getSecurityLevel((SecretKey) key));
         } catch (KeyStoreException | UnrecoverableKeyException | NoSuchAlgorithmException e) {
             throw new CryptoFailedException("Could not get key from Keystore", e);
         } catch (KeyStoreAccessException e) {
@@ -197,5 +244,47 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
     @NonNull
     private String getDefaultServiceIfEmpty(@NonNull String service) {
         return service.isEmpty() ? DEFAULT_SERVICE : service;
+    }
+
+    @TargetApi(Build.VERSION_CODES.P)
+    private SecretKey tryGenerateStrongBoxSecurityKey(String service) throws NoSuchAlgorithmException,
+      InvalidAlgorithmParameterException, NoSuchProviderException {
+        // StrongBox is only supported on Android P and higher
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return null;
+        }
+        try {
+            return generateKey(getKeyGenSpecBuilder(service).setIsStrongBoxBacked(true).build());
+        } catch (StrongBoxUnavailableException e) {
+            Log.i(TAG, "StrongBox is unavailable on this device");
+            return null;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private SecretKey tryGenerateRegularSecurityKey(String service) throws NoSuchAlgorithmException,
+      InvalidAlgorithmParameterException, NoSuchProviderException {
+        return generateKey(getKeyGenSpecBuilder(service).build());
+    }
+
+    // returns true if the key was generated successfully
+    @TargetApi(Build.VERSION_CODES.M)
+    private SecretKey generateKey(KeyGenParameterSpec spec) throws NoSuchProviderException,
+      NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        KeyGenerator generator = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM, KEYSTORE_TYPE);
+        generator.init(spec);
+        return generator.generateKey();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private KeyGenParameterSpec.Builder getKeyGenSpecBuilder(String service) {
+        return new KeyGenParameterSpec.Builder(
+                service,
+                KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+            .setBlockModes(ENCRYPTION_BLOCK_MODE)
+            .setEncryptionPaddings(ENCRYPTION_PADDING)
+            .setRandomizedEncryptionRequired(true)
+            //.setUserAuthenticationRequired(true) // Will throw InvalidAlgorithmParameterException if there is no fingerprint enrolled on the device
+            .setKeySize(ENCRYPTION_KEY_SIZE);
     }
 }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ import { NativeModules, Platform } from 'react-native';
 const { RNKeychainManager } = NativeModules;
 
 export const SECURITY_LEVEL = Object.freeze({
-  ANY: SECURITY_LEVEL_ANY,
-  SECURE_SOFTWARE: SECURITY_LEVEL_SECURE_SOFTWARE,
-  SECURE_HARDWARE: SECURITY_LEVEL_SECURE_HARDWARE,
+  ANY: NativeModules.SECURITY_LEVEL_ANY,
+  SECURE_SOFTWARE: NativeModules.SECURITY_LEVEL_SECURE_SOFTWARE,
+  SECURE_HARDWARE: NativeModules.SECURITY_LEVEL_SECURE_HARDWARE,
 });
 
 export const ACCESSIBLE = Object.freeze({
@@ -63,7 +63,7 @@ export type Options = {
  * on the current device.
  * @return {Promise} Resolves to `SECURITY_LEVEL` when supported, otherwise `null`.
  */
-export function getSecurityLevel(): Promise {
+export function getSecurityLevel(): Promise<SecMinimumLevel> {
     if (!RNKeychainManager.getSecurityLevel){
         return Promise.resolve(null);
     }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ import { NativeModules, Platform } from 'react-native';
 const { RNKeychainManager } = NativeModules;
 
 export const SECURITY_LEVEL = Object.freeze({
-  ANY: 'ANY',
-  SECURE_SOFTWARE: 'SECURE_SOFTWARE',
-  SECURE_HARDWARE: 'SECURE_HARDWARE',
+  ANY: SECURITY_LEVEL_ANY,
+  SECURE_SOFTWARE: SECURITY_LEVEL_SECURE_SOFTWARE,
+  SECURE_HARDWARE: SECURITY_LEVEL_SECURE_HARDWARE,
 });
 
 export const ACCESSIBLE = Object.freeze({

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ export type Options = {
  * on the current device.
  * @return {Promise} Resolves to `SECURITY_LEVEL` when supported, otherwise `null`.
  */
-export function getSecurityLevel(): Promise<SecMinimumLevel> {
+export function getSecurityLevel(): Promise<SecMinimumLevel?> {
     if (!RNKeychainManager.getSecurityLevel){
         return Promise.resolve(null);
     }

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ export type Options = {
   authenticationPrompt?: string,
   authenticationType?: LAPolicy,
   service?: string,
+  securityLevel?: SecMinimumLevel,
 };
 
 /**
@@ -98,8 +99,6 @@ export function getSupportedBiometryType(): Promise<?($Values<typeof BIOMETRY_TY
  * @param {string} server URL to server.
  * @param {string} username Associated username or e-mail to be saved.
  * @param {string} password Associated password to be saved.
- * @param {string} minimumSecurityLevel `SECURITY_LEVEL` defines which security
- *                 level is minimally acceptable for this password.
  * @param {object} options Keychain options, iOS only
  * @return {Promise} Resolves to `true` when successful
  */
@@ -107,14 +106,13 @@ export function setInternetCredentials(
   server: string,
   username: string,
   password: string,
-  minimumSecurityLevel?: SecMinimumLevel,
   options?: Options
 ): Promise<void> {
   return RNKeychainManager.setInternetCredentialsForServer(
     server,
     username,
     password,
-    getMinimumSecurityLevel(minimumSecurityLevel),
+    getMinimumSecurityLevel(options),
     options
   );
 }
@@ -170,34 +168,29 @@ function getOptionsArgument(serviceOrOptions?: string | Options) {
     : serviceOrOptions;
 }
 
-function getMinimumSecurityLevel(minimumSecurityLevel?: SecMinimumLevel) {
-    if (minimumSecurityLevel === undefined) {
-        return SECURITY_LEVEL.ANY;
-    } else {
-        return minimumSecurityLevel
-    }
+function getMinimumSecurityLevel(serviceOrOptions?: string | Options) {
+  return typeof serviceOrOptions === 'object'
+    ? serviceOrOptions.securityLevel
+    : SECURITY_LEVEL.ANY;
 }
 
 /**
  * Saves the `username` and `password` combination for `service`.
  * @param {string} username Associated username or e-mail to be saved.
  * @param {string} password Associated password to be saved.
- * @param {string} minimumSecurityLevel `SECURITY_LEVEL` defines which security
- *                 level is minimally acceptable for this password.
  * @param {string|object} serviceOrOptions Reverse domain name qualifier for the service, defaults to `bundleId` or an options object.
  * @return {Promise} Resolves to `true` when successful
  */
 export function setGenericPassword(
   username: string,
   password: string,
-  minimumSecurityLevel?: SecMinimumLevel,
   serviceOrOptions?: string | Options
 ): Promise<boolean> {
   return RNKeychainManager.setGenericPasswordForOptions(
     getOptionsArgument(serviceOrOptions),
     username,
     password,
-    getMinimumSecurityLevel(minimumSecurityLevel)
+    getMinimumSecurityLevel(serviceOrOptions)
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ import { NativeModules, Platform } from 'react-native';
 const { RNKeychainManager } = NativeModules;
 
 export const SECURITY_LEVEL = Object.freeze({
-  ANY: NativeModules.SECURITY_LEVEL_ANY,
-  SECURE_SOFTWARE: NativeModules.SECURITY_LEVEL_SECURE_SOFTWARE,
-  SECURE_HARDWARE: NativeModules.SECURITY_LEVEL_SECURE_HARDWARE,
+  ANY: RNKeychainManager.SECURITY_LEVEL_ANY,
+  SECURE_SOFTWARE: RNKeychainManager.SECURITY_LEVEL_SECURE_SOFTWARE,
+  SECURE_HARDWARE: RNKeychainManager.SECURITY_LEVEL_SECURE_HARDWARE,
 });
 
 export const ACCESSIBLE = Object.freeze({
@@ -63,7 +63,7 @@ export type Options = {
  * on the current device.
  * @return {Promise} Resolves to `SECURITY_LEVEL` when supported, otherwise `null`.
  */
-export function getSecurityLevel(): Promise<SecMinimumLevel?> {
+export function getSecurityLevel(): Promise<?($Values<typeof SECURITY_LEVEL>)> {
     if (!RNKeychainManager.getSecurityLevel){
         return Promise.resolve(null);
     }
@@ -169,9 +169,13 @@ function getOptionsArgument(serviceOrOptions?: string | Options) {
 }
 
 function getMinimumSecurityLevel(serviceOrOptions?: string | Options) {
-  return typeof serviceOrOptions === 'object'
-    ? serviceOrOptions.securityLevel
-    : SECURITY_LEVEL.ANY;
+  var specifiedLevel = undefined;
+
+  if (typeof serviceOrOptions === 'object') {
+    specifiedLevel = serviceOrOptions.securityLevel;
+  }
+
+  return specifiedLevel || SECURITY_LEVEL.ANY;
 }
 
 /**


### PR DESCRIPTION
**Background**.
Sometimes, we want to make sure that the encryption key that is generated for keychain on Android has a minimum security guarantee. It shouldn't be possible to add items to keychain that might compromise the security.

Also, sometimes we just want to disable certain features if security guarantees are too weak.

We needed that for our application (Status.im), and we thought that that is a good idea to upstream.

I'll be happy for any feedback!

---

**Implementation**

Supported security levels:
- ANY
- SECURE_SOFTWARE
- SECURE_HARDWARE (TEE or SE guarantees).

(1) Add `getSecurityLevel()` API that returns which security level is
supported on this Android version and the specific device.

(2) For APIs that store credentials, an additional optional parameter was added
that fails storing the credentials if the security level is not what is
expected.

```
// Store the credentials.
// Will fail if Keychain can't guarantee at least SECURE_HARDWARE level of encryption key.
await Keychain.setGenericPassword(username, password, Keychain.SECURITY_LEVEL.SECURE_HARDWARE);
```

(3) StrongBox support on Android 9+ (and supported devices [Pixel 3]). Try to generate the key in StrongBox first, and use regular Keychain if that fails.