### PR TITLE
Fix UnrecoverableKeyException crash in android 8

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -42,6 +42,8 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
                     ENCRYPTION_BLOCK_MODE + "/" +
                     ENCRYPTION_PADDING;
     public static final int ENCRYPTION_KEY_SIZE = 256;
+    private boolean retry = true;
+
 
     @Override
     public String getCipherStorageName() {
@@ -64,11 +66,26 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
                 generateKeyAndStoreUnderAlias(service);
             }
 
-            Key key = keyStore.getKey(service, null);
-
+            Key key = null;
+            try {
+                key = keyStore.getKey(service, null);
+            } catch (UnrecoverableKeyException ex) {
+                ex.printStackTrace();
+                // Fix for android.security.KeyStoreException: Invalid key blob
+                // more info: https://stackoverflow.com/questions/36488219/android-security-keystoreexception-invalid-key-blob/36846085#36846085
+                if (retry) {
+                    retry = false;
+                    keyStore.deleteEntry(service);
+                    return encrypt(service, username, password);
+                } else {
+                    throw ex;
+                }
+            }
+          
             byte[] encryptedUsername = encryptString(key, service, username);
             byte[] encryptedPassword = encryptString(key, service, password);
-
+          
+            retry = true;
             return new EncryptionResult(encryptedUsername, encryptedPassword, this);
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | NoSuchProviderException | UnrecoverableKeyException e) {
             throw new CryptoFailedException("Could not encrypt data for service " + service, e);


### PR DESCRIPTION
I have catch this bug in android emulator in Nexus 6 API 27. It crashed because `keyStore.containsAlias(service)` were returned true, but `keyStore.getKey(service, null)` were crashed with exceptions:
```
java.security.UnrecoverableKeyException: Failed to obtain information about key
Caused by: android.security.KeyStoreException: Invalid key blob
at android.security.KeyStore.getKeyStoreException(KeyStore.java:697)
at android.security.keystore.AndroidKeyStoreProvider.loadAndroidKeyStoreSecretKeyFromKeystore(AndroidKeyStoreProvider.java:283)
```
This fix may be related to https://github.com/oblador/react-native-keychain/issues/157