### PR TITLE
Fix iOS memory leaks

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -336,6 +336,7 @@ RCT_EXPORT_METHOD(getGenericPasswordForOptions:(NSDictionary *)options resolver:
   NSString *username = (NSString *) [found objectForKey:(__bridge id)(kSecAttrAccount)];
   NSString *password = [[NSString alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)] encoding:NSUTF8StringEncoding];
 
+  CFRelease(foundTypeRef);
   return resolve(@{
     @"service": service,
     @"username": username,
@@ -430,6 +431,7 @@ RCT_EXPORT_METHOD(getInternetCredentialsForServer:(NSString *)server withOptions
   NSString *username = (NSString *) [found objectForKey:(__bridge id)(kSecAttrAccount)];
   NSString *password = [[NSString alloc] initWithData:[found objectForKey:(__bridge id)(kSecValueData)] encoding:NSUTF8StringEncoding];
 
+  CFRelease(foundTypeRef);
   return resolve(@{
     @"server": server,
     @"username": username,


### PR DESCRIPTION
When we create a Core Foundation object, we're responsible for releasing it after we're done with it. `foundTypeRef`, a `CFTypeRef`, was created but not released after use, causing a memory leak. This was fixed by calling `CFRelease(foundTypeRef)` after use.

Fixes #174 

Tested with the KeychainExample app and profiled in Instruments. 

Before changes:
![image](https://user-images.githubusercontent.com/19519564/52545198-a7c23880-2d83-11e9-992a-d0bf48ece7f1.png)

After changes:
![image](https://user-images.githubusercontent.com/19519564/52545203-aee94680-2d83-11e9-8d6d-bc276501d50e.png)
