### PR TITLE
Fix getGenericPassword() definitions

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -79,7 +79,7 @@ declare module 'react-native-keychain' {
 
     function getGenericPassword(
         options?: Options
-    ): Promise<boolean | {service: string, username: string, password: string}>;
+    ): Promise<false | {service: string, username: string, password: string}>;
 
     function resetGenericPassword(
         options?: Options


### PR DESCRIPTION
From the documentation:

> Resolves to { username, password } if an entry exists or false if it doesn't.

This fix allows you to have patterns like the following in typescript:

```typescript
const auth = Keychain.getGenericPassword();

if (auth) {
  const { username, password } = auth;

  // ...
}
```

whereas without it, ts complains about the possibility of `auth` maybe being just `true`.