### PR TITLE
Fix a crash on Android 4.x devices, handle key not present error messages better

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -275,9 +275,13 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         }
         try {
             return generateKey(getKeyGenSpecBuilder(service).setIsStrongBoxBacked(true).build());
-        } catch (StrongBoxUnavailableException e) {
+        } catch (Exception e) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && e instanceof StrongBoxUnavailableException) {
             Log.i(TAG, "StrongBox is unavailable on this device");
-            return null;
+          } else {
+            Log.e(TAG, "An error occurred when trying to generate a StrongBoxSecurityKey: " + e.getMessage());
+          }
+          return null;
         }
     }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -276,7 +276,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
         try {
             return generateKey(getKeyGenSpecBuilder(service).setIsStrongBoxBacked(true).build());
         } catch (Exception e) {
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && e instanceof StrongBoxUnavailableException) {
+          if (e instanceof StrongBoxUnavailableException) {
             Log.i(TAG, "StrongBox is unavailable on this device");
           } else {
             Log.e(TAG, "An error occurred when trying to generate a StrongBoxSecurityKey: " + e.getMessage());

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -113,10 +113,10 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
                     throw ex;
                 }
             }
-          
+
             byte[] encryptedUsername = encryptString(key, service, username);
             byte[] encryptedPassword = encryptString(key, service, password);
-          
+
             retry = true;
             return new EncryptionResult(encryptedUsername, encryptedPassword, this);
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | NoSuchProviderException | UnrecoverableKeyException e) {
@@ -168,6 +168,9 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             KeyStore keyStore = getKeyStoreAndLoad();
 
             Key key = keyStore.getKey(service, null);
+            if (key == null) {
+              throw new CryptoFailedException("The provided service/key could not be found in the Keystore");
+            }
 
             String decryptedUsername = decryptBytes(key, username);
             String decryptedPassword = decryptBytes(key, password);
@@ -213,7 +216,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             cipherOutputStream.close();
             return outputStream.toByteArray();
         } catch (Exception e) {
-            throw new CryptoFailedException("Could not encrypt value for service " + service, e);
+            throw new CryptoFailedException("Could not encrypt value for service " + service + ", message: " + e.getMessage(), e);
         }
     }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -238,7 +238,7 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             }
             return new String(output.toByteArray(), Charset.forName("UTF-8"));
         } catch (Exception e) {
-            throw new CryptoFailedException("Could not decrypt bytes", e);
+            throw new CryptoFailedException("Could not decrypt bytes: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
When a key is not found, in v2.0.0 an error message that "Could not decrypt bytes" would come up. I think in v3 this becomes "Unknown error: Could not decrypt bytes".

This is due to the key being retrieved being null when calling
`cipher.init(Cipher.DECRYPT_MODE, key, ivParams);`, which then fails with an error "java.security.InvalidKeyException: Only SecretKey is supported". So the error messaging around this is really vague and difficult to understand.

This PR adds the exception message in this case to the exception being generated, but for the key not found case another exception is constructed that is easier to understand.

Additionally, while trying to test this I found the module was causing a crash on my API 19 emulator that it could not find a StrongBoxUnavailableException. I'm not a full time Android programmer, so I found a way of dealing with it and it *seems* to work OK, but please check and see if this is the preferred way of dealing with it.