### PR TITLE
fix: remove key if failed to generate with sufficient security level

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
@@ -155,7 +155,13 @@ public class CipherStorageKeystoreAESCBC implements CipherStorage {
             secretKey = tryGenerateRegularSecurityKey(service);
         }
 
-        if(!validateKeySecurityLevel(requiredLevel, secretKey)) {
+        if (!validateKeySecurityLevel(requiredLevel, secretKey)) {
+            try {
+                removeKey(service);
+            } catch (KeyStoreAccessException e) {
+                Log.e(TAG, "Unable to remove key from keychain", e);
+            }
+
             throw new CryptoFailedException("Cannot generate keys with required security guarantees");
         }
     }


### PR DESCRIPTION
currently, if validateKeySecurityLevel fails on key generation, the key remains in the keystore, and a subsequent add for that same key will succeed due to this check:
https://github.com/oblador/react-native-keychain/blob/5f5c651f9978bfe134914e02113d0ea4f9cd9331/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java#L97