### PR TITLE
Refine flow type for getGenericPassword response

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ export type SharedWebCredentials = {|
  */
 export function getGenericPassword(
   serviceOrOptions?: string | Options
-): Promise<boolean | SharedWebCredentials> {
+): Promise<false | SharedWebCredentials> {
   return RNKeychainManager.getGenericPasswordForOptions(
     getOptionsArgument(serviceOrOptions)
   );


### PR DESCRIPTION
If I understand correctly, `true` should never come back from `getGenericPassword` instead a successful call will resolve with an object while a failure will resolve with `false`. 

`boolean` is approximately equivalent to `true | false`, so we should be able to eliminate the `true` case here.