### PR TITLE
Add typings for Android Security Levels 

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -11,7 +11,7 @@ declare module 'react-native-keychain' {
         password: string;
     }
 
-    export enum ACCESSIBLE   {
+    export enum ACCESSIBLE {
         WHEN_UNLOCKED = "AccessibleWhenUnlocked",
         AFTER_FIRST_UNLOCK = "AccessibleAfterFirstUnlock",
         ALWAYS = "AccessibleAlways",
@@ -34,6 +34,12 @@ declare module 'react-native-keychain' {
     export enum LAPolicy {
         DEVICE_PASSCODE_OR_BIOMETRICS = "AuthenticationWithBiometricsDevicePasscode",
         BIOMETRICS = "AuthenticationWithBiometrics"
+    }
+
+    export enum SECURITY_LEVEL {
+        SECURE_SOFTWARE,
+        SECURE_HARDWARE,
+        ANY
     }
 
     export interface Options {
@@ -79,13 +85,13 @@ declare module 'react-native-keychain' {
 
     function getGenericPassword(
         options?: Options
-    ): Promise<false | {service: string, username: string, password: string}>;
+    ): Promise<false | { service: string, username: string, password: string }>;
 
     function resetGenericPassword(
         options?: Options
     ): Promise<boolean>
 
-    function requestSharedWebCredentials (
+    function requestSharedWebCredentials(
     ): Promise<SharedWebCredentials>;
 
     function setSharedWebCredentials(
@@ -94,4 +100,6 @@ declare module 'react-native-keychain' {
         password: string
     ): Promise<void>;
 
+    function getSecurityLevel(
+    ): Promise<SECURITY_LEVEL>
 }

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -49,6 +49,7 @@ declare module 'react-native-keychain' {
         authenticationPrompt?: string;
         authenticationType?: LAPolicy;
         service?: string;
+        securityLevel? : SECURITY_LEVEL;
     }
 
     function canImplyAuthentication(


### PR DESCRIPTION
Typescript unable to work properly with security levels feature. Adding typings is fixing this issue.

Changes:
* enum with SECURITY_LEVEL options
* add typed return value for getSecurityLevel
* add securityLevel to Options signature