### PR TITLE
Fix biometryType detection if disabled by user

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -270,7 +270,7 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve rejec
 {
   NSError *aerr = nil;
   LAContext *context = [LAContext new];
-  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
+  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
 
   if (!aerr && canBeProtected) {
     if (@available(iOS 11, *)) {

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -121,6 +121,7 @@ NSString *accessGroupValue(NSDictionary *options)
 
 #define kAuthenticationType @"authenticationType"
 #define kAuthenticationTypeBiometrics @"AuthenticationWithBiometrics"
+#define kLAPolicyDeviceOwnerAuthentication @"DeviceOwnerAuthentication"
 
 #define kAccessControlType @"accessControl"
 #define kAccessControlUserPresence @"UserPresence"
@@ -270,7 +271,7 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve rejec
 {
   NSError *aerr = nil;
   LAContext *context = [LAContext new];
-  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
+  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
 
   if (!aerr && canBeProtected) {
     if (@available(iOS 11, *)) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export const ACCESS_CONTROL = Object.freeze({
 export const AUTHENTICATION_TYPE = Object.freeze({
   DEVICE_PASSCODE_OR_BIOMETRICS: 'AuthenticationWithBiometricsDevicePasscode',
   BIOMETRICS: 'AuthenticationWithBiometrics',
+  DEVICE_OWNER: 'DeviceOwnerAuthentication',
 });
 
 export const BIOMETRY_TYPE = Object.freeze({
@@ -87,11 +88,11 @@ export function canImplyAuthentication(options?: Options): Promise<boolean> {
  * Get what type of hardware biometry support the device has.
  * @return {Promise} Resolves to a `BIOMETRY_TYPE` when supported, otherwise `null`
  */
-export function getSupportedBiometryType(): Promise<?($Values<typeof BIOMETRY_TYPE>)> {
+export function getSupportedBiometryType(options?: Options): Promise<?($Values<typeof BIOMETRY_TYPE>)> {
   if (!RNKeychainManager.getSupportedBiometryType) {
     return Promise.resolve(null);
   }
-  return RNKeychainManager.getSupportedBiometryType();
+  return RNKeychainManager.getSupportedBiometryType(options);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ export const ACCESS_CONTROL = Object.freeze({
 export const AUTHENTICATION_TYPE = Object.freeze({
   DEVICE_PASSCODE_OR_BIOMETRICS: 'AuthenticationWithBiometricsDevicePasscode',
   BIOMETRICS: 'AuthenticationWithBiometrics',
-  DEVICE_OWNER: 'DeviceOwnerAuthentication',
 });
 
 export const BIOMETRY_TYPE = Object.freeze({
@@ -49,7 +48,10 @@ export type LAPolicy = $Values<typeof AUTHENTICATION_TYPE>;
 
 export type SecMinimumLevel = $Values<typeof SECURITY_LEVEL>;
 
-export type Options = {
+export type 
+  
+  
+  = {
   accessControl?: SecAccessControl,
   accessGroup?: string,
   accessible?: SecAccessible,
@@ -88,11 +90,11 @@ export function canImplyAuthentication(options?: Options): Promise<boolean> {
  * Get what type of hardware biometry support the device has.
  * @return {Promise} Resolves to a `BIOMETRY_TYPE` when supported, otherwise `null`
  */
-export function getSupportedBiometryType(options?: Options): Promise<?($Values<typeof BIOMETRY_TYPE>)> {
+export function getSupportedBiometryType(): Promise<?($Values<typeof BIOMETRY_TYPE>)> {
   if (!RNKeychainManager.getSupportedBiometryType) {
     return Promise.resolve(null);
   }
-  return RNKeychainManager.getSupportedBiometryType(options);
+  return RNKeychainManager.getSupportedBiometryType();
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -48,10 +48,7 @@ export type LAPolicy = $Values<typeof AUTHENTICATION_TYPE>;
 
 export type SecMinimumLevel = $Values<typeof SECURITY_LEVEL>;
 
-export type 
-  
-  
-  = {
+export type Options = {
   accessControl?: SecAccessControl,
   accessGroup?: string,
   accessible?: SecAccessible,


### PR DESCRIPTION
This fixes an issue where the `getSupportedBiometryType` method would return `null` in cases where a device does supports biometrics but the setting is disabled or blocked. This made it difficult to differentiate between a device that does support biometrics (but they are disabled) and one that has no support for biometrics at all.