### PR TITLE
Update getSupportedBiometryType policy

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -270,7 +270,7 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve rejec
 {
   NSError *aerr = nil;
   LAContext *context = [LAContext new];
-  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
+  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
 
   if (!aerr && canBeProtected) {
     if (@available(iOS 11, *)) {


### PR DESCRIPTION
Updates the policy used for `canEvaluatePolicy` to `LAPolicyDeviceOwnerAuthentication` which enables developers to determine the device's `biometryType` even if the permissions are denied or blocked.