### PR TITLE
4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keychain",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "description": "Keychain Access for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
went for a major version bump because of androidX support