### PR TITLE
Simplify installation instructions for newer RN

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Keychain/Keystore Access for React Native.
 ## Installation
 
 1. Run `yarn add react-native-keychain`
-    1. **Only for React Native <= 0.59**: `$ react-native link react-native-keychain` and check `MainApplication.java` to verify the package was added. See manual installation below if you have issues with `react-native link`.
-1. Run `pod install` in `ios/` directory to install iOS dependencies.
-1. Re-run your Android and iOS projects.
+
+    1 a. **Only for React Native <= 0.59**: `$ react-native link react-native-keychain` and check `MainApplication.java` to verify the package was added. See manual installation below if you have issues with `react-native link`.
+2. Run `pod install` in `ios/` directory to install iOS dependencies.
+3. Re-build your Android and iOS projects.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Keychain/Keystore Access for React Native.
 
 ## Installation
 
-1. `$ yarn add react-native-keychain`
-2. `$ react-native link react-native-keychain` and check `MainApplication.java` to verify the package was added.
-3. Rebuild your project with `react-native run-ios/android`
-
-See manual installation below if you have issues with `react-native link`.
+1. Run `yarn add react-native-keychain`
+    1. **Only for React Native <= 0.59**: `$ react-native link react-native-keychain` and check `MainApplication.java` to verify the package was added. See manual installation below if you have issues with `react-native link`.
+1. Run `pod install` in `ios/` directory to install iOS dependencies.
+1. Re-run your Android and iOS projects.
 
 ## Usage
 


### PR DESCRIPTION
Linking is not necessary anymore since React Native 0.60. I've added a note about it in the installation instructions.