### PR TITLE
Update npmignore and files package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,1 @@
-# Logs
-*.log
-
-# Dependency directory
-node_modules
-
-KeychainExample
-
-.editorconfig
-
-test_index.js
+KeychainExample/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "4.0.0",
   "description": "Keychain Access for React Native",
   "main": "index.js",
+  "files": [
+    "android",
+    "RNKeychain.xcodeproj",
+    "RNKeychainManager",
+    "typings",
+    "RNKeychain.podspec"
+  ],
   "scripts": {
     "test": "flow"
   },


### PR DESCRIPTION
A quick update to `.npmignore` and the `files` section in `package.json` that reduces the distribution artifact size by more than 70% (mainly by no longer including Gradle wrapper, which is not used by app consumers).

Before:

```
npm notice name:          react-native-keychain
npm notice version:       4.0.0
npm notice filename:      react-native-keychain-4.0.0.tgz
npm notice package size:  79.7 kB
npm notice unpacked size: 172.2 kB
npm notice total files:   31
```

After:

```
npm notice name:          react-native-keychain
npm notice version:       4.0.0
npm notice filename:      react-native-keychain-4.0.0.tgz
npm notice package size:  22.9 kB
npm notice unpacked size: 103.8 kB
npm notice total files:   22
```

CC @SaeedZhiany