### PR TITLE
Document required FaceID permission for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Keychain/Keystore Access for React Native.
 
     1 a. **Only for React Native <= 0.59**: `$ react-native link react-native-keychain` and check `MainApplication.java` to verify the package was added. See manual installation below if you have issues with `react-native link`.
 2. Run `pod install` in `ios/` directory to install iOS dependencies.
-3. Re-build your Android and iOS projects.
+3. If you want to support FaceID, add a `NSFaceIDUsageDescription` entry in your `Info.plist`.
+4. Re-build your Android and iOS projects.
 
 ## Usage
 


### PR DESCRIPTION
Hi,

My application was crashing when a user was trying to call `Keychain.getGenericPassword` on an iPhoneX.

It turned out I needed to add a `NSFaceIDUsageDescription` entry in my `Info.plist` to ask for permission to use FaceID, which was not documented on this project.

I added it in the installation steps as I believe we should be warned about this during installation.