### PR TITLE
Fix TS typing (LAPolicy -> AUTHENTICATION_TYPE)

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -31,7 +31,7 @@ declare module 'react-native-keychain' {
         BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE = "BiometryCurrentSetOrDevicePasscode"
     }
 
-    export enum LAPolicy {
+    export enum AUTHENTICATION_TYPE {
         DEVICE_PASSCODE_OR_BIOMETRICS = "AuthenticationWithBiometricsDevicePasscode",
         BIOMETRICS = "AuthenticationWithBiometrics"
     }


### PR DESCRIPTION
Fixes an incorrect TypeScript type reference (`LAPolicy` doesn't exist and should be `AUTHENTICATION_TYPE`)