### PR TITLE
Add more details to getSupportedBiometryType()

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Inquire if the type of local authentication policy is supported on this device w
 ### `getSupportedBiometryType()`
 
 Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
+> This method returns `null`, if the device haven't enrolled into fingerprint/FaceId. Even though it has hardware for it.
 
 ### `getSecurityLevel()` (Android only)
 


### PR DESCRIPTION
Add more clarity to when it returns `null`. 
Got stuck, when I was assuming this lib is broken, on android device with fingerprint reader, but not enrolled in Fingerprint.