### PR TITLE
Support macOS Catalyst

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ The `setInternetCredentials(server, username, password)` call will be resolved a
 
 If you need Keychain Sharing in your iOS extension, make sure you use the same App Group and Keychain Sharing group names in your Main App and your Share Extension. To then share the keychain between the Main App and Share Extension, use the `accessGroup` and `service` option on `setGenericPassword` and `getGenericPassword`, like so: `getGenericPassword({ accessGroup: 'group.appname', service: 'com.example.appname' })`
 
+### macOS Catalyst
+
+This package supports macOS Catalyst.
+
 ### Security
 
 On API levels that do not support Android keystore, Facebook Conceal is used to en/decrypt stored data. The encrypted data is then stored in SharedPreferences. Since Conceal itself stores its encryption key in SharedPreferences, it follows that if the device is rooted (or if an attacker can somehow access the filesystem), the key can be obtained and the stored data can be decrypted. Therefore, on such a device, the conceal encryption is only an obscurity. On API level 23+ the key is stored in the Android Keystore, which makes the key non-exportable and therefore makes the entire process more secure. Follow best practices and do not store user credentials on a device. Instead use tokens or other forms of authentication and re-ask for user credentials before performing sensitive operations.

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -452,7 +452,7 @@ RCT_EXPORT_METHOD(resetInternetCredentialsForServer:(NSString *)server withOptio
   return resolve(@(YES));
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 RCT_EXPORT_METHOD(requestSharedWebCredentials:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {


### PR DESCRIPTION
Great news! I'm successfully using this package in my Catalyst project.

However, the [`SecRequestSharedWebCredential`](https://developer.apple.com/documentation/security/1617896-secrequestsharedwebcredential
) and `SecAddSharedWebCredential` functions are not supported in Catalyst, so the corresponding wrapper methods need to be conditionally excluded.
