### PR TITLE
Add BIOMETRY_TYPE enum

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -41,6 +41,12 @@ declare module 'react-native-keychain' {
         SECURE_HARDWARE,
         ANY
     }
+  
+    export enum BIOMETRY_TYPE {
+        TOUCH_ID = 'TouchID',
+        FACE_ID = 'FaceID',
+        FINGERPRINT = 'Fingerprint'
+    }
 
     export interface Options {
         accessControl?: ACCESS_CONTROL;
@@ -57,7 +63,7 @@ declare module 'react-native-keychain' {
     ): Promise<boolean>;
 
     function getSupportedBiometryType(
-    ): Promise<string>;
+    ): Promise<BIOMETRY_TYPE | null>;
 
     function setInternetCredentials(
         server: string,


### PR DESCRIPTION
Currently, getSupportedBiometryType returns generic string, but the enumeration of biometrics type is predefined.

This PR adds BIOMETRIC_TYPE enum to typings and modifies getSupportedBiometryType so it returns value from the enum.