### PR TITLE
Fix return types for getInternetCredentials

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -68,7 +68,7 @@ declare module 'react-native-keychain' {
 
     function getInternetCredentials(
         server: string
-    ): Promise<UserCredentials>;
+    ): Promise<false | UserCredentials>;
 
     function hasInternetCredentials(
         server: string


### PR DESCRIPTION
The TypeScript type definition for `getInternetCredentials` states that it would always return a promise for an object containing `username` and `password`. The [documentation](https://github.com/oblador/react-native-keychain#getinternetcredentialsserver--authenticationprompt-) on the other hand states that it can also return a promise for `false` in case the key is not found in the storage.

Looking at the source code for [iOS](https://github.com/oblador/react-native-keychain/blob/569a408317eb0c0ad6ac1fb46fb82e5b0af59ee0/RNKeychainManager/RNKeychainManager.m#L332) and [Android](https://github.com/oblador/react-native-keychain/blob/653140d27fadf8d9a9c397e44a807f4ccb852003/android/src/main/java/com/oblador/keychain/KeychainModule.java#L109), it seems that the documentation is correct while the type definitions are wrong. Thus I here fix the types.

P.S. The type definition for the similar function `getGenericPassword` already correctly match the documentation.