### PR TITLE
Set usage of StrongBox as part of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Travis](https://img.shields.io/travis/oblador/react-native-keychain.svg)](https://travis-ci.org/oblador/react-native-keychain) [![npm](https://img.shields.io/npm/v/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain) [![npm](https://img.shields.io/npm/dm/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain)
 
-Keychain/Keystore Access for React Native. 
+Keychain/Keystore Access for React Native.
 
 ## Installation
 
@@ -46,7 +46,7 @@ See `KeychainExample` for fully working project example.
 
 Both `setGenericPassword` and `setInternetCredentials` are limited to strings only, so if you need to store objects etc, please use `JSON.stringify`/`JSON.parse` when you store/access it.
 
-### `setGenericPassword(username, password, [{ accessControl, accessible, accessGroup, service, securityLevel }])`
+### `setGenericPassword(username, password, [{ accessControl, accessible, accessGroup, service, securityLevel, useStrongBox }])`
 
 Will store the username/password combination in the secure storage. Resolves to `true` or rejects in case of an error.
 
@@ -102,6 +102,12 @@ If set, `securityLevel` parameter specifies minimum security level that the encr
 * `ANY` - no security guarantees needed (default value); Credentials can be stored in FB Secure Storage;
 * `SECURE_SOFTWARE` - requires for the key to be stored in the Android Keystore, separate from the encrypted data;
 * `SECURE_HARDWARE` - requires for the key to be stored on a secure hardware (Trusted Execution Environment or Secure Environment). Read [this article](https://developer.android.com/training/articles/keystore#ExtractionPrevention) for more information.
+
+### Use StrongBox (Android only)
+
+[StrongBox](https://developer.android.com/training/articles/keystore#HardwareSecurityModule) is an implementation of the Keymaster HAL that resides in a hardware security module. In order to prevent errors with different hardwares and keep the same encryptation method through all android devices, it's possible to skip the usage of it.
+
+If the option `useStrongBox` is set as `false`, the security key would be generated using the regular service. Default: `true`
 
 ### Options
 
@@ -200,7 +206,7 @@ include ':app'
 + project(':react-native-keychain').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keychain/android')
 ```
 
-* Edit `android/app/build.gradle` (note: **app** folder) to look like this: 
+* Edit `android/app/build.gradle` (note: **app** folder) to look like this:
 
 ```diff
 apply plugin: 'com.android.application'
@@ -238,7 +244,7 @@ public class MainActivity extends extends ReactActivity {
   ...
 }
 ```
-  
+
 #### Proguard Rules
 
 On Android builds that use proguard (like release), you may see the following error:
@@ -298,7 +304,7 @@ Now your tests should run successfully, though note that writing and reading to 
 
 ## Notes
 
-### Android 
+### Android
 
 The module will automatically use the appropriate CipherStorage implementation based on API level:
 

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -72,7 +72,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setGenericPasswordForOptions(String service, String username, String password, String minimumSecurityLevel, Promise promise) {
+    public void setGenericPasswordForOptions(String service, String username, String password, String minimumSecurityLevel, boolean useStrongBox, Promise promise) {
         try {
             SecurityLevel level = SecurityLevel.valueOf(minimumSecurityLevel);
             if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
@@ -83,7 +83,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
             CipherStorage currentCipherStorage = getCipherStorageForCurrentAPILevel();
             validateCipherStorageSecurityLevel(currentCipherStorage, level);
 
-            EncryptionResult result = currentCipherStorage.encrypt(service, username, password, level);
+            EncryptionResult result = currentCipherStorage.encrypt(service, username, password, level, useStrongBox);
             prefsStorage.storeEncryptedEntry(service, result);
 
             promise.resolve(true);
@@ -152,7 +152,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
 
     private void migrateCipherStorage(String service, CipherStorage newCipherStorage, CipherStorage oldCipherStorage, DecryptionResult decryptionResult) throws KeyStoreAccessException, CryptoFailedException {
         // don't allow to degrade security level when transferring, the new storage should be as safe as the old one.
-        EncryptionResult encryptionResult = newCipherStorage.encrypt(service, decryptionResult.username, decryptionResult.password, decryptionResult.getSecurityLevel());
+        EncryptionResult encryptionResult = newCipherStorage.encrypt(service, decryptionResult.username, decryptionResult.password, decryptionResult.getSecurityLevel(), false);
         // store the encryption result
         prefsStorage.storeEncryptedEntry(service, encryptionResult);
         // clean up the old cipher storage
@@ -198,7 +198,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setInternetCredentialsForServer(@NonNull String server, String username, String password, String minimumSecurityLevel, ReadableMap unusedOptions, Promise promise) {
-        setGenericPasswordForOptions(server, username, password, minimumSecurityLevel, promise);
+        setGenericPasswordForOptions(server, username, password, minimumSecurityLevel, false, promise);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
@@ -39,7 +39,7 @@ public interface CipherStorage {
       }
     }
 
-    EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level) throws CryptoFailedException;
+    EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level, boolean useStrongBox) throws CryptoFailedException;
 
     DecryptionResult decrypt(@NonNull String service, @NonNull byte[] username, @NonNull byte[] password) throws CryptoFailedException;
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
@@ -46,7 +46,7 @@ public class CipherStorageFacebookConceal implements CipherStorage {
     }
 
     @Override
-    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level) throws CryptoFailedException {
+    public EncryptionResult encrypt(@NonNull String service, @NonNull String username, @NonNull String password, SecurityLevel level, boolean useStrongBox) throws CryptoFailedException {
 
         if (!this.securityLevel().satisfiesSafetyThreshold(level)) {
             throw new CryptoFailedException(String.format("Insufficient security level (wants %s; got %s)", level, this.securityLevel()));

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ export type Options = {
   authenticationType?: LAPolicy,
   service?: string,
   securityLevel?: SecMinimumLevel,
+  useStrongBox?: boolean
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -178,6 +178,16 @@ function getMinimumSecurityLevel(serviceOrOptions?: string | Options) {
   return specifiedLevel || SECURITY_LEVEL.ANY;
 }
 
+function getUseStrongBoxOption(serviceOrOptions?: string | Options) {
+  var useStrongBox = true;
+
+  if (typeof serviceOrOptions === 'object') {
+    useStrongBox = serviceOrOptions.useStrongBox;
+  }
+
+  return useStrongBox;
+}
+
 /**
  * Saves the `username` and `password` combination for `service`.
  * @param {string} username Associated username or e-mail to be saved.
@@ -194,7 +204,8 @@ export function setGenericPassword(
     getOptionsArgument(serviceOrOptions),
     username,
     password,
-    getMinimumSecurityLevel(serviceOrOptions)
+    getMinimumSecurityLevel(serviceOrOptions),
+    getUseStrongBoxOption(serviceOrOptions)
   );
 }
 

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -41,7 +41,7 @@ declare module 'react-native-keychain' {
         SECURE_HARDWARE,
         ANY
     }
-  
+
     export enum BIOMETRY_TYPE {
         TOUCH_ID = 'TouchID',
         FACE_ID = 'FaceID',
@@ -56,6 +56,7 @@ declare module 'react-native-keychain' {
         authenticationType?: LAPolicy;
         service?: string;
         securityLevel? : SECURITY_LEVEL;
+        useStrongBox? : boolean
     }
 
     function canImplyAuthentication(


### PR DESCRIPTION
As suggested [here](https://github.com/oblador/react-native-keychain/pull/232#issuecomment-547388572) this PR will bring the option of disabling StrongBox usage. 

Example:
```
await Keychain.setGenericPassword(username, password, {useStrongBox: true});
```