### PR TITLE
Update react-native-keychain.d.ts

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -53,7 +53,7 @@ declare module 'react-native-keychain' {
         accessGroup?: string;
         accessible?: ACCESSIBLE;
         authenticationPrompt?: string;
-        authenticationType?: LAPolicy;
+        authenticationType?: AUTHENTICATION_TYPE;
         service?: string;
         securityLevel? : SECURITY_LEVEL;
     }


### PR DESCRIPTION
The latest update `4.0.2` changed `LAPolicy` to `AUTHENTICATION_TYPE` in the declaration but forgot to update it here.

closes #282