### PR TITLE
Update getSupportedBiometryType docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Inquire if the type of local authentication policy is supported on this device w
 ### `getSupportedBiometryType()`
 
 Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
-> This method returns `null`, if the device haven't enrolled into fingerprint/FaceId. Even though it has hardware for it.
 
 ### `getSecurityLevel()` (Android only)
 


### PR DESCRIPTION
Removes a notice under `getSupportedBiometryType` that is no longer valid after a recent API change (https://github.com/oblador/react-native-keychain/pull/240) . This method always returns the biometry type, if the device supports it. It only returns `null` if the device doesn't support any of the biometry types.