### PR TITLE
Fix broken hasInternetCredentials on iOS

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -398,6 +398,7 @@ RCT_EXPORT_METHOD(setInternetCredentialsForServer:(NSString *)server
 }
 
 RCT_EXPORT_METHOD(hasInternetCredentialsForServer:(NSString *)server
+                  withOptions:(NSDictionary * __nullable)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
On the latest release (5.0.0) `hasInternetCredentials` function is broken on iOS, because Javascript passes some extra options (as described on #306).
This PR adds this extra parameter.