### PR TITLE
Don't fail authentication flow onAuthenticationFailed

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -813,8 +813,6 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     @Override
     public void onAuthenticationFailed() {
       final CryptoFailedException error = new CryptoFailedException("Authentication failed. User Not recognized.");
-
-      onDecrypt(null, error);
     }
 
     /** trigger interactive authentication. */

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -809,12 +809,6 @@ public class KeychainModule extends ReactContextBaseJavaModule {
       }
     }
 
-    /** Called when a biometric is valid but not recognized. */
-    @Override
-    public void onAuthenticationFailed() {
-      final CryptoFailedException error = new CryptoFailedException("Authentication failed. User Not recognized.");
-    }
-
     /** trigger interactive authentication. */
     public void startAuthentication() {
       final FragmentActivity activity = (FragmentActivity) getCurrentActivity();


### PR DESCRIPTION
As described in #305, failing the whole flow in the `onAuthenticationFailed` callback seems incorrect.
The BiometricPrompt stays open if your fingerprint is not recognized for some reason (a common occurence), but fails to complete after matching.

This PR disables onAuthenticationFailed entirely.