### PR TITLE
Restore default behaviour for setGenericPassword on Android

### DIFF
--- a/KeychainExample/App.js
+++ b/KeychainExample/App.js
@@ -13,7 +13,7 @@ import SegmentedControlTab from 'react-native-segmented-control-tab';
 import * as Keychain from 'react-native-keychain';
 
 const ACCESS_CONTROL_OPTIONS = ['None', 'Passcode', 'Password'];
-const ACCESS_CONTROL_OPTIONS_ANDROID = ['Default'];
+const ACCESS_CONTROL_OPTIONS_ANDROID = ['None'];
 const ACCESS_CONTROL_MAP = [
   null,
   Keychain.ACCESS_CONTROL.DEVICE_PASSCODE,

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Get security level that is supported on the current device with the current OS. 
 
 | Key                        | Platform     | Description                                                                                      | Default                                                      |
 | -------------------------- | ------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| **`accessControl`**        | All          | This dictates how a keychain item may be used, see possible values in `Keychain.ACCESS_CONTROL`. | _None_ (iOS), `BIOMETRY_ANY` default for Android.            |
+| **`accessControl`**        | All          | This dictates how a keychain item may be used, see possible values in `Keychain.ACCESS_CONTROL`. | _None_                                                       |
 | **`accessible`**           | iOS only     | This dictates when a keychain item is accessible, see possible values in `Keychain.ACCESSIBLE`.  | _`Keychain.ACCESSIBLE.WHEN_UNLOCKED`_                        |
 | **`accessGroup`**          | iOS only     | In which App Group to share the keychain. Requires additional setup with entitlements.           | _None_                                                       |
 | **`authenticationPrompt`** | iOS only     | What to prompt the user when unlocking the keychain with biometry or device password.            | `Authenticate to retrieve secret`                            |
@@ -181,7 +181,7 @@ Get security level that is supported on the current device with the current OS. 
 
 > Note #1: `BIOMETRY_ANY`, `BIOMETRY_CURRENT_SET`, `BIOMETRY_ANY_OR_DEVICE_PASSCODE`, `BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE` - recognized by Android as a requirement for Biometric enabled storage (Till we got a better implementation);
 >
-> Note #2: For Android we support only two states: `Default` (use the best available secured storage) and `Fingerprint` (use only biometric protected storage);
+> Note #2: For Android we support only two states: `None` (default) and `Fingerprint` (use only biometric protected storage);
 
 Refs:
 

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -51,7 +51,8 @@ public class KeychainModule extends ReactContextBaseJavaModule {
 
   private static final String LOG_TAG = KeychainModule.class.getSimpleName();
 
-  @StringDef({AccessControl.USER_PRESENCE
+  @StringDef({AccessControl.NONE
+    , AccessControl.USER_PRESENCE
     , AccessControl.BIOMETRY_ANY
     , AccessControl.BIOMETRY_CURRENT_SET
     , AccessControl.DEVICE_PASSCODE
@@ -59,6 +60,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     , AccessControl.BIOMETRY_ANY_OR_DEVICE_PASSCODE
     , AccessControl.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE})
   @interface AccessControl {
+    String NONE = "None";
     String USER_PRESENCE = "UserPresence";
     String BIOMETRY_ANY = "BiometryAny";
     String BIOMETRY_CURRENT_SET = "BiometryCurrentSet";
@@ -464,11 +466,11 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     return storageName;
   }
 
-  /** Get access control value from options or fallback to {@link AccessControl#BIOMETRY_ANY}. */
+  /** Get access control value from options or fallback to {@link AccessControl#NONE}. */
   @AccessControl
   @NonNull
   private static String getAccessControlOrDefault(@Nullable final ReadableMap options) {
-    return getAccessControlOrDefault(options, AccessControl.BIOMETRY_ANY);
+    return getAccessControlOrDefault(options, AccessControl.NONE);
   }
 
   /** Get access control value from options or fallback to default. */
@@ -517,8 +519,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     return AccessControl.BIOMETRY_ANY.equals(accessControl)
       || AccessControl.BIOMETRY_CURRENT_SET.equals(accessControl)
       || AccessControl.BIOMETRY_ANY_OR_DEVICE_PASSCODE.equals(accessControl)
-      || AccessControl.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE.equals(accessControl)
-      || null == accessControl; /* by default we force biometry */
+      || AccessControl.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE.equals(accessControl);
   }
 
   private void addCipherStorageToMap(@NonNull final CipherStorage cipherStorage) {


### PR DESCRIPTION
**PR Description**

The default behaviour for `setGenericPassword` is different for iOS vs Android in v5.0.0 of this library. This PR aims to fix that.

**Details**

In v4.0.5 of `react-native-keychain` the default implementation allows users to set and get generic passwords in both iOS and Android without having to authenticate themselves. By passing `options` it is possible to modify this default behaviour.

In v5.0.0 the above still holds true for iOS. However, the default behaviour changed on Android devices that support biometrics. Such devices will prompt users to authenticate themselves even when passwords are stored without passing an `accessControl` value as an option, since they use the best available secured storage by default when setting passwords.

**Fix**

This PR restores the default behaviour on Android. Settings and getting secrets no longer forces a user to authenticate themselves by default. If passwords need to be stored in a more secure way, the `accessControl` option can be used.

**Recordings**

I have made some videos to illustrate the difference in behaviour. The file linked below contains recordings for using `getGenericPassword` and `setGenericPassword` with default settings in the following environments:
- v4.0.5 on Android
- master on iOS
- master on Android
- master + changes from this PR on Android

[react-native-keychain-recordings.zip](https://github.com/oblador/react-native-keychain/files/4432490/react-native-keychain-recordings.zip)
