### PR TITLE
fix: workaround for type errors from Flow 0.107

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -81,4 +81,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.105.2
+^0.107.0

--- a/index.js
+++ b/index.js
@@ -67,14 +67,14 @@ export type SecSecurityRules = $Values<typeof SECURITY_RULES>;
 
 export type SecBiometryType = $Values<typeof BIOMETRY_TYPE>;
 
-export type AuthenticationPrompt = {
+export type AuthenticationPrompt = {|
   title?: string,
   subtitle?: string,
   description?: string,
   cancel?: string,
-};
+|};
 
-type BaseOptions = {
+type BaseOptions = {|
   accessControl?: SecAccessControl,
   accessGroup?: string,
   accessible?: SecAccessible,
@@ -83,7 +83,7 @@ type BaseOptions = {
   securityLevel?: SecMinimumLevel,
   storage?: SecStorageType,
   rules?: SecSecurityRules,
-};
+|};
 
 type NormalizedOptions = {
   authenticationPrompt?: AuthenticationPrompt,
@@ -116,7 +116,7 @@ const AUTH_PROMPT_DEFAULTS = {
   cancel: 'Cancel',
 };
 
-function normalizeServiceOption(serviceOrOptions?: string | Options): Options {
+function normalizeServiceOption(serviceOrOptions?: string | Options) {
   if (typeof serviceOrOptions === 'string') {
     console.warn(
       `You passed a service string as an argument to one of the react-native-keychain functions.
@@ -155,6 +155,7 @@ function normalizeOptions(
     };
   }
 
+  // $FlowFixMe >=0.107.x – remove in next major, when authenticationPrompt as string is removed
   return options;
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "flow-bin": "0.105.2",
+    "flow-bin": "^0.107.0",
     "react-native": "^0.61.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,10 +1948,10 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-flow-bin@0.105.2:
-  version "0.105.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.105.2.tgz#9d03d5ae3e1d011e311f309cb8786b3b3695fec2"
-  integrity sha512-VCHt0SCjFPviv/Ze/W7AgkcE0uH4TocypSFA8wR3ZH1P7BSjny4l3uhHyOjzU3Qo1i0jO4NyaU6q3Y5IaQ6xng==
+flow-bin@^0.107.0:
+  version "0.107.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.107.0.tgz#b37bfcce51204d35d58f8eb93b3a76b52291e4cc"
+  integrity sha512-hsmwO5Q0+XUXaO2kIKLpleUNNBSFcsGEQGBOTEC/KR/4Ez695I1fweX/ioSjbU4RWhPZhkIqnpbF9opVAauCHg==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Flow 0.107 is the latest version compatible with React Native 0.61. This PR fixes errors that surface with this version compared to currently used 0.105, by introducing a workaround, since the code that fails is only temporary. It's tricky to type objects that transform to other objects, and unfortunately I don't have enough time to fix it properly. That's why I believe this "fix" is sufficient. 

FYI, React Native 0.62 bumps Flow to 0.113, while still being compatible with 0.116. This library is currently not compatible with 0.116, including having this fix. However, removing code responsible for normalizing config would fix that. My suggestion – remove deprecated APIs (`service` as a string and `authenticationPrompt` as a string) when migrating to React Native 0.62 and bumping major version of this lib. 