### PR TITLE
Adds missing interface for promptInfoOptions attribute

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -62,6 +62,13 @@ declare module 'react-native-keychain' {
     AUTOMATIC_UPGRADE = 'automaticUpgradeToMoreSecuredStorage',
   }
 
+  export interface PromptInfoOptions {
+    title: string;
+    subtitle?: string;
+    description?: string;
+    cancel?: string;
+  }
+
   export interface AuthenticationPrompt {
     title?: string;
     subtitle?: string;


### PR DESCRIPTION
Adds a missing (for some reason) interface. Due to its absence, compilation errors occurred without the skipLibCheck rule enabled to `true`.

Also, as I see, you have an existing `AuthenticationPrompt` interface, but with optional `title`. This one requires `title`.