### PR TITLE
Increase UserAuthenticationValidityDuration to fix UserNotAuthenticatedException

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -225,7 +225,7 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
       .setEncryptionPaddings(PADDING_PKCS1)
       .setRandomizedEncryptionRequired(true)
       .setUserAuthenticationRequired(true)
-      .setUserAuthenticationValidityDurationSeconds(1)
+      .setUserAuthenticationValidityDurationSeconds(5)
       .setKeySize(ENCRYPTION_KEY_SIZE);
   }
 


### PR DESCRIPTION
Increase `UserAuthenticationValidityDurationSeconds` in `CipherStorageKeychainRsaEcb.java` to 5 seconds as suggested in this comment: https://github.com/oblador/react-native-keychain/issues/318#issuecomment-607346478

I was experiencing the same `UserNotAuthenticatedException` on a Samsung S7 (Android 7.0), and making this change fixed this issue.
