### PR TITLE
Add face and iris recognition identification - Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Get security level that is supported on the current device with the current OS. 
 
 > Note #1: `BIOMETRY_ANY`, `BIOMETRY_CURRENT_SET`, `BIOMETRY_ANY_OR_DEVICE_PASSCODE`, `BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE` - recognized by Android as a requirement for Biometric enabled storage (Till we got a better implementation);
 >
-> Note #2: For Android we support only two states: `None` (default) and `Fingerprint` (use only biometric protected storage);
+> Note #2: For Android we support only two states: `None` (default) and `Fingerprint` (use only biometric protected storage); `Face` recognition fails with "User not authenticated" exception, see issue #318
 
 Refs:
 
@@ -225,11 +225,13 @@ Refs:
 
 #### `Keychain.BIOMETRY_TYPE` enum
 
-| Key               | Description                                                     |
-| ----------------- | --------------------------------------------------------------- |
-| **`TOUCH_ID`**    | Device supports authentication with Touch ID. (iOS only)        |
-| **`FACE_ID`**     | Device supports authentication with Face ID. (iOS only)         |
-| **`FINGERPRINT`** | Device supports authentication with Fingerprint. (Android only) |
+| Key               | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| **`TOUCH_ID`**    | Device supports authentication with Touch ID. (iOS only)             |
+| **`FACE_ID`**     | Device supports authentication with Face ID. (iOS only)              |
+| **`FINGERPRINT`** | Device supports authentication with Fingerprint. (Android only)      |
+| **`FACE`**        | Device supports authentication with Face Recognition. (Android only) |
+| **`IRIS`**        | Device supports authentication with Iris Recognition. (Android only) |
 
 Refs:
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,12 +17,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 28)
+  compileSdkVersion safeExtGet('compileSdkVersion', 29)
   buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 19)
-    targetSdkVersion safeExtGet('targetSdkVersion', 28)
+    targetSdkVersion safeExtGet('targetSdkVersion', 29)
     versionCode 1
     versionName "1.0"
   }

--- a/android/src/main/java/com/oblador/keychain/DeviceAvailability.java
+++ b/android/src/main/java/com/oblador/keychain/DeviceAvailability.java
@@ -1,8 +1,10 @@
 package com.oblador.keychain;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.KeyguardManager;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
@@ -16,9 +18,21 @@ import static androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS;
  */
 @SuppressWarnings({"WeakerAccess", "deprecation"})
 public class DeviceAvailability {
-  public static boolean isFingerprintAuthAvailable(@NonNull final Context context) {
+  public static boolean isBiometricAuthAvailable(@NonNull final Context context) {
     return BiometricManager.from(context).canAuthenticate() == BIOMETRIC_SUCCESS;
   }
+
+  public static boolean isFingerprintAuthAvailable(@NonNull final Context context) {
+    return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_FINGERPRINT);
+  }
+
+  public static boolean isFaceAuthAvailable(@NonNull final Context context) {
+    return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_FACE);
+  }
+
+    public static boolean isIrisAuthAvailable(@NonNull final Context context) {
+        return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_IRIS);
+    }
 
   /** Check is permissions granted for biometric things. */
   public static boolean isPermissionsGranted(@NonNull final Context context) {

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -48,6 +48,8 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   //region Constants
   public static final String KEYCHAIN_MODULE = "RNKeychainManager";
   public static final String FINGERPRINT_SUPPORTED_NAME = "Fingerprint";
+  public static final String FACE_SUPPORTED_NAME = "Face";
+  public static final String IRIS_SUPPORTED_NAME = "Iris";
   public static final String EMPTY_STRING = "";
 
   private static final String LOG_TAG = KeychainModule.class.getSimpleName();
@@ -401,7 +403,14 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getSupportedBiometryType(@NonNull final Promise promise) {
     try {
-      final String reply = isFingerprintAuthAvailable() ? FINGERPRINT_SUPPORTED_NAME : null;
+      String reply = null;
+      if(isFaceAuthAvailable()){
+        reply = FACE_SUPPORTED_NAME;
+      } else if(isIrisAuthAvailable()) {
+        reply = IRIS_SUPPORTED_NAME;
+      } else if(isFingerprintAuthAvailable()) {
+        reply = FINGERPRINT_SUPPORTED_NAME;
+      }
 
       promise.resolve(reply);
     } catch (Exception e) {
@@ -669,7 +678,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   /* package */ CipherStorage getCipherStorageForCurrentAPILevel(final boolean useBiometry)
     throws CryptoFailedException {
     final int currentApiLevel = Build.VERSION.SDK_INT;
-    final boolean isBiometry = isFingerprintAuthAvailable() && useBiometry;
+    final boolean isBiometry = (isFingerprintAuthAvailable() || isFaceAuthAvailable() || isIrisAuthAvailable()) && useBiometry;
     CipherStorage foundCipher = null;
 
     for (CipherStorage variant : cipherStorageMap.values()) {
@@ -734,7 +743,17 @@ public class KeychainModule extends ReactContextBaseJavaModule {
 
   /** True - if fingerprint hardware available and configured, otherwise false. */
   /* package */ boolean isFingerprintAuthAvailable() {
-    return DeviceAvailability.isFingerprintAuthAvailable(getReactApplicationContext());
+    return DeviceAvailability.isBiometricAuthAvailable(getReactApplicationContext()) && DeviceAvailability.isFingerprintAuthAvailable(getReactApplicationContext());
+  }
+
+  /** True - if face recognition hardware available and configured, otherwise false. */
+  /* package */ boolean isFaceAuthAvailable() {
+    return DeviceAvailability.isBiometricAuthAvailable(getReactApplicationContext()) && DeviceAvailability.isFaceAuthAvailable(getReactApplicationContext());
+  }
+
+  /** True - if iris recognition hardware available and configured, otherwise false. */
+  /* package */ boolean isIrisAuthAvailable() {
+    return DeviceAvailability.isBiometricAuthAvailable(getReactApplicationContext()) && DeviceAvailability.isIrisAuthAvailable(getReactApplicationContext());
   }
 
   /** Is secured hardware a part of current storage or not. */

--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ export const BIOMETRY_TYPE = Object.freeze({
   TOUCH_ID: 'TouchID',
   FACE_ID: 'FaceID',
   FINGERPRINT: 'Fingerprint',
+  FACE: 'Face',
+  IRIS: 'Iris',
 });
 
 export const STORAGE_TYPE = Object.freeze({

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -48,6 +48,8 @@ declare module 'react-native-keychain' {
     TOUCH_ID = 'TouchID',
     FACE_ID = 'FaceID',
     FINGERPRINT = 'Fingerprint',
+    FACE = 'Face',
+    IRIS = 'Iris',
   }
 
   export enum STORAGE_TYPE {


### PR DESCRIPTION
This PR extends the existing enums and native android code to be able to identify the biometry type enrolled on the device.
Previously the library assumed that it was always Fingerprint, but that's not always the case, e.g. on a Pixel 4, which has no fingerprint sensor.