### PR TITLE
Branches/filter slow devices

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -39,9 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import javax.crypto.Cipher;
 
 @SuppressWarnings({"unused", "WeakerAccess", "SameParameterValue"})
 public class KeychainModule extends ReactContextBaseJavaModule {
@@ -148,38 +145,6 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     }
   }
 
-  /** Allow initialization in chain. */
-  public static KeychainModule withWarming(@NonNull final ReactApplicationContext reactContext) {
-    final KeychainModule instance = new KeychainModule(reactContext);
-
-    // force initialization of the crypto api in background thread
-    final Thread warmingUp = new Thread(instance::internalWarmingBestCipher, "keychain-warming-up");
-    warmingUp.setDaemon(true);
-    warmingUp.start();
-
-    return instance;
-  }
-
-  /** cipher (crypto api) warming up logic. force java load classes and intializations. */
-  private void internalWarmingBestCipher() {
-    try {
-      final long startTime = System.nanoTime();
-
-      Log.v(KEYCHAIN_MODULE, "warming up started at " + startTime);
-      final CipherStorageBase best = (CipherStorageBase) getCipherStorageForCurrentAPILevel();
-      final Cipher instance = best.getCachedInstance();
-      final boolean isSecure = best.supportsSecureHardware();
-      final SecurityLevel requiredLevel = isSecure ? SecurityLevel.SECURE_HARDWARE : SecurityLevel.SECURE_SOFTWARE;
-      best.generateKeyAndStoreUnderAlias("warmingUp", requiredLevel);
-      best.getKeyStoreAndLoad();
-
-      Log.v(KEYCHAIN_MODULE, "warming up takes: " +
-        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) +
-        " ms");
-    } catch (Throwable ex) {
-      Log.e(KEYCHAIN_MODULE, "warming up failed!", ex);
-    }
-  }
   //endregion
 
   //region Overrides

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -34,6 +34,7 @@ import com.oblador.keychain.cipherStorage.CipherStorageKeystoreRsaEcb.NonInterac
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.EmptyParameterException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
+import com.oblador.keychain.workaround.IDeviceFilter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -132,10 +133,16 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   //region Initialization
 
   /** Default constructor. */
-  public KeychainModule(@NonNull final ReactApplicationContext reactContext) {
+  public KeychainModule(@NonNull final ReactApplicationContext reactContext, @NonNull final IDeviceFilter deviceFilter) {
     super(reactContext);
     prefsStorage = new PrefsStorage(reactContext);
 
+  // Exclude the refactored code from the execution path to keep it aligned with the old version as much as possible.
+  // NOTE: This may result in reduction of the encryption capabilities.
+  // TODO Unwrap this workaround once the problem is resolved
+  if (deviceFilter.isDeviceAffected()) {
+    // TODO Add a fallback Cipher
+  } else {
     addCipherStorageToMap(new CipherStorageFacebookConceal(reactContext));
     addCipherStorageToMap(new CipherStorageKeystoreAesCbc());
 
@@ -143,6 +150,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       addCipherStorageToMap(new CipherStorageKeystoreRsaEcb());
     }
+  }
   }
 
   //endregion

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
@@ -1,0 +1,25 @@
+package com.oblador.keychain;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+public class KeychainModuleBuilder {
+  private final ReactApplicationContext reactContext;
+  private boolean useWarmingUp = true;
+
+  public KeychainModuleBuilder(ReactApplicationContext reactContext) {
+    this.reactContext = reactContext;
+  }
+
+  public KeychainModuleBuilder usingWarmUp(boolean useWarmUp) {
+    this.useWarmingUp = useWarmUp;
+    return this;
+  }
+
+  public KeychainModule build() {
+    if (useWarmingUp) {
+      return new KeychainModuleWithWarmUp(reactContext);
+    } else {
+      return new KeychainModule(reactContext);
+    }
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
@@ -1,13 +1,26 @@
 package com.oblador.keychain;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.workaround.IDeviceFilter;
+import com.oblador.keychain.workaround.ListDeviceFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 
 public class KeychainModuleBuilder {
   private final ReactApplicationContext reactContext;
+  private final List<IDeviceFilter> filters = new ArrayList<>();
   private boolean useWarmingUp = true;
 
   public KeychainModuleBuilder(ReactApplicationContext reactContext) {
     this.reactContext = reactContext;
+  }
+
+  public KeychainModuleBuilder workaroundAffectedDevices(IDeviceFilter... filters) {
+    this.filters.addAll(asList(filters));
+    return this;
   }
 
   public KeychainModuleBuilder usingWarmUp(boolean useWarmUp) {
@@ -16,10 +29,11 @@ public class KeychainModuleBuilder {
   }
 
   public KeychainModule build() {
+    ListDeviceFilter filter = new ListDeviceFilter(filters);
     if (useWarmingUp) {
-      return new KeychainModuleWithWarmUp(reactContext);
+      return new KeychainModuleWithWarmUp(reactContext, filter);
     } else {
-      return new KeychainModule(reactContext);
+      return new KeychainModule(reactContext, filter);
     }
   }
 }

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleWithWarmUp.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleWithWarmUp.java
@@ -1,0 +1,47 @@
+package com.oblador.keychain;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorageBase;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.crypto.Cipher;
+
+public class KeychainModuleWithWarmUp extends KeychainModule {
+    /**
+     * Default constructor.
+     *
+     * @param reactContext
+     */
+    public KeychainModuleWithWarmUp(@NonNull ReactApplicationContext reactContext) {
+      super(reactContext);
+
+      // force initialization of the crypto api in background thread
+      final Thread warmingUp = new Thread(this::internalWarmingBestCipher, "keychain-warming-up");
+      warmingUp.setDaemon(true);
+      warmingUp.start();
+    }
+
+  /** cipher (crypto api) warming up logic. force java load classes and intializations. */
+  private void internalWarmingBestCipher() {
+    final long startTime = System.nanoTime();
+
+    try {
+      Log.v(KEYCHAIN_MODULE, "warming up started at " + startTime);
+      final CipherStorageBase best = (CipherStorageBase) getCipherStorageForCurrentAPILevel();
+      final Cipher instance = best.getCachedInstance();
+      final boolean isSecure = best.supportsSecureHardware();
+      final SecurityLevel requiredLevel = isSecure ? SecurityLevel.SECURE_HARDWARE : SecurityLevel.SECURE_SOFTWARE;
+      best.generateKeyAndStoreUnderAlias("warmingUp", requiredLevel);
+      best.getKeyStoreAndLoad();
+    } catch (Throwable ex) {
+      Log.e(KEYCHAIN_MODULE, "warming up failed!", ex);
+    }
+
+    Log.v(KEYCHAIN_MODULE, "warming up takes: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + " ms");
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleWithWarmUp.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleWithWarmUp.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.oblador.keychain.cipherStorage.CipherStorageBase;
+import com.oblador.keychain.workaround.IDeviceFilter;
 
 import java.util.concurrent.TimeUnit;
 
@@ -16,9 +17,10 @@ public class KeychainModuleWithWarmUp extends KeychainModule {
      * Default constructor.
      *
      * @param reactContext
+     * @param deviceFilter
      */
-    public KeychainModuleWithWarmUp(@NonNull ReactApplicationContext reactContext) {
-      super(reactContext);
+    public KeychainModuleWithWarmUp(@NonNull ReactApplicationContext reactContext, IDeviceFilter deviceFilter) {
+      super(reactContext, deviceFilter);
 
       // force initialization of the crypto api in background thread
       final Thread warmingUp = new Thread(this::internalWarmingBestCipher, "keychain-warming-up");

--- a/android/src/main/java/com/oblador/keychain/KeychainPackage.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainPackage.java
@@ -21,7 +21,7 @@ public class KeychainPackage implements ReactPackage {
   @Override
   @NonNull
   public List<NativeModule> createNativeModules(@NonNull final ReactApplicationContext reactContext) {
-    return Collections.singletonList(KeychainModule.withWarming(reactContext));
+    return Collections.singletonList(new KeychainModuleWithWarmUp(reactContext));
   }
 
   @NonNull

--- a/android/src/main/java/com/oblador/keychain/KeychainPackage.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainPackage.java
@@ -21,7 +21,9 @@ public class KeychainPackage implements ReactPackage {
   @Override
   @NonNull
   public List<NativeModule> createNativeModules(@NonNull final ReactApplicationContext reactContext) {
-    return Collections.singletonList(new KeychainModuleWithWarmUp(reactContext));
+    return Collections.singletonList(
+      new KeychainModuleBuilder(reactContext)
+        .build());
   }
 
   @NonNull

--- a/android/src/main/java/com/oblador/keychain/KeychainPackage.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainPackage.java
@@ -7,6 +7,8 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
+import com.oblador.keychain.workaround.Issue314Filter;
+import com.oblador.keychain.workaround.Issue337Filter;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,8 +23,10 @@ public class KeychainPackage implements ReactPackage {
   @Override
   @NonNull
   public List<NativeModule> createNativeModules(@NonNull final ReactApplicationContext reactContext) {
-    return Collections.singletonList(
-      new KeychainModuleBuilder(reactContext)
+    return Collections.singletonList(new KeychainModuleBuilder(reactContext)
+        .workaroundAffectedDevices(
+          new Issue314Filter(),
+          new Issue337Filter())
         .build());
   }
 

--- a/android/src/main/java/com/oblador/keychain/workaround/IDeviceFilter.java
+++ b/android/src/main/java/com/oblador/keychain/workaround/IDeviceFilter.java
@@ -1,0 +1,9 @@
+package com.oblador.keychain.workaround;
+
+/**
+ * @deprecated This is intermittent solution. Do NOT use in permanent code.
+ */
+@Deprecated
+public interface IDeviceFilter {
+  boolean isDeviceAffected();
+}

--- a/android/src/main/java/com/oblador/keychain/workaround/Issue314Filter.java
+++ b/android/src/main/java/com/oblador/keychain/workaround/Issue314Filter.java
@@ -1,0 +1,42 @@
+package com.oblador.keychain.workaround;
+
+import android.os.Build;
+
+/**
+ * This filter disables the Cipher implementation for certain devices which reportedly suffer bad performance.
+ *
+ * From https://github.com/oblador/react-native-keychain/issues/314:
+ * "Android UI freezing on launch"
+ *
+ * Known affected devices:
+ * Samsung A20 Android 10  - warmup time was anything between 5k-40k ms. Android 8 and 9 were not visibly affected.
+ * Huawei y7 pro - warmup time 20s
+ * OnePlus 5T (A5010) running OxygenOS 9.0.10 - warming up takes: 17296 ms
+ *
+ * @deprecated Must be removed as soon as Issue 314 is fixed.
+ */
+@Deprecated
+public class Issue314Filter implements IDeviceFilter {
+  private static final int ANDROID_9  = 28;
+  private static final int ANDROID_10 = 29;
+
+  @Override
+  public boolean isDeviceAffected() {
+    // Samsung A20 running  Android 10
+    if ("SAMSUNG".equalsIgnoreCase(Build.MANUFACTURER) && Build.MODEL.startsWith("SM-A205") && Build.VERSION.SDK_INT == ANDROID_10) {
+      return true;
+    }
+
+    // Huawei y7 pro
+    if ("HUAWEI".equalsIgnoreCase(Build.MANUFACTURER) && Build.MODEL.contains("HWY7PRO")) {
+      return true;
+    }
+
+    // OnePlus 5T (A5010) running OxygenOS 9.0.10
+    if ("OnePlus5".equalsIgnoreCase(Build.PRODUCT) && Build.VERSION.SDK_INT == ANDROID_9) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/workaround/Issue337Filter.java
+++ b/android/src/main/java/com/oblador/keychain/workaround/Issue337Filter.java
@@ -1,0 +1,36 @@
+package com.oblador.keychain.workaround;
+
+import android.os.Build;
+
+/**
+ * This filter disables the Cipher implementation for certain devices which reportedly suffer bad performance.
+ *
+ * From https://github.com/oblador/react-native-keychain/issues/337:
+ * "getGenericPassword is too slow on android 10"
+ *
+ * Known affected devices:
+ * Samsung SM-J730F (API28) it takes way beyond 10 seconds
+ * Samsung Galaxy S10+, running Android 10 - 3637ms average over 5 runs.
+ *
+ * @deprecated Must be removed as soon as Issue 314 is fixed.
+ */
+@Deprecated
+public class Issue337Filter implements IDeviceFilter {
+  private static final int API28 = 28;
+  private static final int ANDROID_10 = 29;
+
+  @Override
+  public boolean isDeviceAffected() {
+    // Samsung SM-J730F (API28)
+    if ("SAMSUNG".equalsIgnoreCase(Build.MANUFACTURER) && "SM-J730F".equalsIgnoreCase(Build.MODEL) && Build.VERSION.SDK_INT == API28) {
+      return true;
+    }
+
+    // Samsung Galaxy S10+, running Android 10
+    if ("SAMSUNG".equalsIgnoreCase(Build.MANUFACTURER) && "SM-G975F".equalsIgnoreCase(Build.MODEL) && Build.VERSION.SDK_INT == ANDROID_10) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/workaround/ListDeviceFilter.java
+++ b/android/src/main/java/com/oblador/keychain/workaround/ListDeviceFilter.java
@@ -1,0 +1,24 @@
+package com.oblador.keychain.workaround;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+public class ListDeviceFilter implements IDeviceFilter {
+  private final List<IDeviceFilter> filters;
+
+  public ListDeviceFilter(@NonNull final List<IDeviceFilter> filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  public boolean isDeviceAffected() {
+    for (IDeviceFilter deviceFilter : filters) {
+      if (deviceFilter.isDeviceAffected()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
+++ b/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
@@ -106,7 +106,7 @@ public class KeychainModuleTests {
   public void testFingerprintNoHardware_api21() throws Exception {
     // GIVEN: API21 android version
     ReactApplicationContext context = getRNContext();
-    KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
 
     // WHEN: verify availability
     final int result = BiometricManager.from(context).canAuthenticate();
@@ -127,7 +127,7 @@ public class KeychainModuleTests {
     //   fingerprint api available but not configured properly
     //   API23 android version
     ReactApplicationContext context = getRNContext();
-    KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
 
     // set that hardware is available
     FingerprintManager fm = (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
@@ -158,7 +158,7 @@ public class KeychainModuleTests {
 
     // WHEN: check availability
     final int result = BiometricManager.from(context).canAuthenticate();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final boolean isFingerprintWorking = module.isFingerprintAuthAvailable();
 
     // THEN: biometric works
@@ -183,7 +183,7 @@ public class KeychainModuleTests {
 
     // WHEN: verify availability
     final int result = BiometricManager.from(context).canAuthenticate();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final boolean isFingerprintWorking = module.isFingerprintAuthAvailable();
 
     // THEN: biometrics works
@@ -199,7 +199,7 @@ public class KeychainModuleTests {
     final ReactApplicationContext context = getRNContext();
 
     // WHEN: ask keychain for secured storage
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final CipherStorage storage = module.getCipherStorageForCurrentAPILevel();
 
     // THEN: expected Facebook cipher storage, its the only one that supports API19
@@ -219,7 +219,7 @@ public class KeychainModuleTests {
     final ReactApplicationContext context = getRNContext();
 
     // WHEN: get the best secured storage
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final CipherStorage storage = module.getCipherStorageForCurrentAPILevel();
 
     // THEN:
@@ -247,7 +247,7 @@ public class KeychainModuleTests {
     shadowOf(fm).setDefaultFingerprints(5); // 5 fingerprints are available
 
     // WHEN: fingerprint availability influence on storage selection
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final boolean isFingerprintWorking = module.isFingerprintAuthAvailable();
     final CipherStorage storage = module.getCipherStorageForCurrentAPILevel();
 
@@ -278,7 +278,7 @@ public class KeychainModuleTests {
 
     // WHEN: get secured storage
     final int result = BiometricManager.from(context).canAuthenticate();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final boolean isFingerprintWorking = module.isFingerprintAuthAvailable();
     final CipherStorage storage = module.getCipherStorageForCurrentAPILevel();
 
@@ -304,7 +304,7 @@ public class KeychainModuleTests {
 
     final CipherStorage.DecryptionResult decrypted = new CipherStorage.DecryptionResult("user", "password");
     final CipherStorage.EncryptionResult encrypted = new CipherStorage.EncryptionResult("user".getBytes(), "password".getBytes(), rsa);
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final SharedPreferences prefs = context.getSharedPreferences(PrefsStorage.KEYCHAIN_DATA, Context.MODE_PRIVATE);
 
     when(
@@ -334,7 +334,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_Unspecified_api28() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // WHEN:
@@ -349,7 +349,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_Unspecified_api23() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // WHEN:
@@ -364,7 +364,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_Unspecified_api21() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // WHEN:
@@ -379,7 +379,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_Unspecified_api19() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // WHEN:
@@ -394,7 +394,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_NoBiometry_api28() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // WHEN:
@@ -412,7 +412,7 @@ public class KeychainModuleTests {
   public void testGetSecurityLevel_NoBiometry_NoSecuredHardware_api28() throws Exception {
     // GIVE:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final Promise mockPromise = mock(Promise.class);
 
     // set key info - software method
@@ -438,7 +438,7 @@ public class KeychainModuleTests {
   public void testDowngradeBiometricToAes_api28() throws Exception {
     // GIVEN:
     final ReactApplicationContext context = getRNContext();
-    final KeychainModule module = new KeychainModule(context);
+    final KeychainModule module = builder.build();
     final PrefsStorage prefs = new PrefsStorage(context);
     final Cipher mockCipher = Mockito.mock(Cipher.class);
     final KeyStore mockKeyStore = Mockito.mock(KeyStore.class);

--- a/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
+++ b/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
@@ -84,11 +84,16 @@ public class KeychainModuleTests {
    */
   private FakeProvider provider = new FakeProvider();
 
+  private KeychainModuleBuilder builder;
+
   @Before
   public void setUp() throws Exception {
     provider.configuration.clear();
 
     Security.insertProviderAt(provider, 0);
+
+    builder = new KeychainModuleBuilder(getRNContext())
+                    .usingWarmUp(false);
   }
 
   @After


### PR DESCRIPTION
# The problem
The performance on _certain_ devices (very small number) is unacceptably slow, which makes this issue block the release of the app. 

Two issues are open at the moment: https://github.com/oblador/react-native-keychain/issues/314 and https://github.com/oblador/react-native-keychain/issues/337

# Investigation
The investigation is in progress. So far the findings are:
The performance degradation happened after the Ciphers have been refactored in the latest version. The refactoring was combined with adding new functionality (biometry). At the moment it is not clear which of the two factors is responsible.

All three Ciphers currently used underwent the refactoring changes. One of them, namely RSA cipher, is confirmed to not have any problems; the other two are unsure.

Reportedly, those devices which experienced bad performance were back to normal after the library was downgraded to the pre-refactoring version.

# This PR
The purpose of this PR is not to fix the issue but to unblock the release of the app. This gives the developers room to investigate and fix properly.

## The approach
The idea is to minimise the impact of changes introduced during the refactoring. Once the app detects that it is running on the affected device, the compromised ciphers will not be loaded. This may degrade the cryptographic capability, though. Therefore this solution cannot be seen as permanent.

## What and where
* The patch is found in `KeychainModule.java`. See the comment near it.
* Detection of the affected devices is done by `Issue314Filter.java` and `Issue337Filter.java`. Once the issues are fixed, the respective filter must be deleted. Filters are already marked as deprecated.
* For easy injecting the filters and warm-up wrapper, a builder `KeychainModuleBuilder ` was introduced.