### PR TITLE
Update getSupportedBiometryType description

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Inquire if the type of local authentication policy is supported on this device w
 
 Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
 
-> This method returns `null`, if the device haven't enrolled into fingerprint/FaceId. Even though it has hardware for it.
+> This method always return supported type even haven't enrolled.
 
 ### `getSecurityLevel([{ accessControl }])` (Android only)
 


### PR DESCRIPTION
getSupportedBiometryType always return supported type even haven't enrolled.