### PR TITLE
Update react-native-keychain.d.ts

### DIFF
--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -91,7 +91,7 @@ declare module 'react-native-keychain' {
 
   function getGenericPassword(
     options?: Options
-  ): Promise<false | SharedWebCredentials>;
+  ): Promise<false | UserCredentials>;
 
   function resetGenericPassword(options?: Options): Promise<boolean>;
 
@@ -107,7 +107,7 @@ declare module 'react-native-keychain' {
   function getInternetCredentials(
     server: string,
     options?: Options
-  ): Promise<false | UserCredentials>;
+  ): Promise<false | SharedWebCredentials>;
 
   function resetInternetCredentials(
     server: string,


### PR DESCRIPTION
Fix apparent type mismatch between `getGenericPassword` vs `getInternetCredentials` since the latter has `server`.