### PR TITLE
Reintroduce a fix for strongbox decryption data corruption (#383)

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
@@ -498,7 +498,7 @@ abstract public class CipherStorageBase implements CipherStorage {
       cipher.init(Cipher.ENCRYPT_MODE, key);
     };
 
-    public static final DecryptBytesHandler<InputStream> decrypt = (cipher, key, input) -> {
+    public static final DecryptBytesHandler decrypt = (cipher, key, input) -> {
       cipher.init(Cipher.DECRYPT_MODE, key);
     };
   }
@@ -515,8 +515,8 @@ abstract public class CipherStorageBase implements CipherStorage {
       final byte[] iv = cipher.getIV();
       output.write(iv, 0, iv.length);
     };
-    /** Read initialization vector from input bytes array and configure cipher by it. */
-    public static final DecryptBytesHandler<byte[]> decrypt = (cipher, key, input) -> {
+    /** Read initialization vector from input stream and configure cipher by it. */
+    public static final DecryptBytesHandler decrypt = (cipher, key, input) -> {
       final IvParameterSpec iv = readIv(input);
       cipher.init(Cipher.DECRYPT_MODE, key, iv);
     };
@@ -553,9 +553,9 @@ abstract public class CipherStorageBase implements CipherStorage {
       throws GeneralSecurityException, IOException;
   }
 
-  /** Handler for configuring cipher by initialization data from input. */
-  public interface DecryptBytesHandler<T> {
-    void initialize(@NonNull final Cipher cipher, @NonNull final Key key, @NonNull final T input)
+  /** Handler for configuring cipher by initialization data from input stream. */
+  public interface DecryptBytesHandler {
+    void initialize(@NonNull final Cipher cipher, @NonNull final Key key, @NonNull final InputStream input)
       throws GeneralSecurityException, IOException;
   }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
@@ -505,7 +505,7 @@ abstract public class CipherStorageBase implements CipherStorage {
     public static IvParameterSpec readIv(@NonNull final byte[] bytes) throws IOException {
       final byte[] iv = new byte[IV_LENGTH];
 
-      if (IV_LENGTH <= bytes.length)
+      if (IV_LENGTH >= bytes.length)
         throw new IOException("Insufficient length of input data for IV extracting.");
 
       System.arraycopy(bytes, 0, iv, 0, IV_LENGTH);

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
@@ -25,6 +25,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
 
 /**
  * @see <a href="https://proandroiddev.com/secure-data-in-android-initialization-vector-6ca1c659762c">Secure Data in Android</a>
@@ -227,15 +228,14 @@ public class CipherStorageKeystoreAesCbc extends CipherStorageBase {
     throws GeneralSecurityException, IOException {
     final Cipher cipher = getCachedInstance();
 
-    // decrypt the bytes using cipher.doFinal(). Using a CipherInputStream for decryption has historically led to issues
-    // on the Pixel family of devices.
-    // see https://github.com/oblador/react-native-keychain/issues/383
     try {
       // read the initialization vector from bytes array
-      if (null != handler) {
-        handler.initialize(cipher, key, bytes);
-      }
+      final IvParameterSpec iv = IV.readIv(bytes);
+      cipher.init(Cipher.DECRYPT_MODE, key, iv);
 
+      // decrypt the bytes using cipher.doFinal(). Using a CipherInputStream for decryption has historically led to issues
+      // on the Pixel family of devices.
+      // see https://github.com/oblador/react-native-keychain/issues/383
       byte[] decryptedBytes = cipher.doFinal(bytes, IV.IV_LENGTH, bytes.length - IV.IV_LENGTH);
       return new String(decryptedBytes, UTF8);
     } catch (Throwable fail) {


### PR DESCRIPTION
A PR (https://github.com/oblador/react-native-keychain/pull/288) a while back was merged to fix an issue where decrypting the keychain using a `CipherInputStream` causes certain Google Pixel devices to throw an exception and hang.

The change seems to have been inadvertently reverted in the large refactoring that took place in https://github.com/oblador/react-native-keychain/pull/260.

This PR reintroduces that fix.