### PR TITLE
Branches/configurable module

### DIFF
--- a/KeychainExample/android/build.gradle
+++ b/KeychainExample/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         /* https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google */
-        classpath 'com.android.tools.build:gradle:4.0.0-beta01'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/README.md
+++ b/README.md
@@ -456,6 +456,32 @@ Encrypted data is stored in SharedPreferences.
 
 The `setInternetCredentials(server, username, password)` call will be resolved as call to `setGenericPassword(username, password, server)`. Use the `server` argument to distinguish between multiple entries.
 
+#### Configuring the Android-specific behavior
+
+Android implementation has behavioural specifics incurred by existing inconsistency between implementations by different vendors. E.g., some Samsung devices show very slow startup of crypto system. To alleviate this, a warm-up strategy is introduced in Android implementation of this library. 
+
+Using default constructor you get default behaviour, i.e. with the warming up on.
+```java
+    private List<ReactPackage> createPackageList() {
+      return Arrays.asList(
+        ...
+        new KeychainPackage(),  // warming up is ON
+        ...
+      )
+
+``` 
+Those who want finer control are required to use constructor with a builder which can be configured as they like:
+```java
+    private List<ReactPackage> createPackageList() {
+      return Arrays.asList(
+        ...
+        new KeychainPackage(
+                new KeychainModuleBuilder()
+                        .withoutWarmUp()),   // warming up is OFF
+        ...
+      )
+```
+
 ### iOS Notes
 
 If you need Keychain Sharing in your iOS extension, make sure you use the same App Group and Keychain Sharing group names in your Main App and your Share Extension. To then share the keychain between the Main App and Share Extension, use the `accessGroup` and `service` option on `setGenericPassword` and `getGenericPassword`, like so: `getGenericPassword({ accessGroup: 'group.appname', service: 'com.example.appname' })`

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
@@ -3,16 +3,33 @@ package com.oblador.keychain;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 public class KeychainModuleBuilder {
+  public static final boolean DEFAULT_USE_WARM_UP = true;
+
   private ReactApplicationContext reactContext;
+  private boolean useWarmUp = DEFAULT_USE_WARM_UP;
 
   public KeychainModuleBuilder withReactContext(ReactApplicationContext reactContext) {
     this.reactContext = reactContext;
     return this;
   }
 
+  public KeychainModuleBuilder usingWarmUp() {
+    useWarmUp = true;
+    return this;
+  }
+
+  public KeychainModuleBuilder withoutWarmUp() {
+    useWarmUp = false;
+    return this;
+  }
+
   public KeychainModule build() {
     validate();
-    return KeychainModule.withWarming(reactContext);
+    if (useWarmUp) {
+      return KeychainModule.withWarming(reactContext);
+    } else {
+      return new KeychainModule(reactContext);
+    }
   }
 
   private void validate() {

--- a/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModuleBuilder.java
@@ -1,0 +1,23 @@
+package com.oblador.keychain;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+public class KeychainModuleBuilder {
+  private ReactApplicationContext reactContext;
+
+  public KeychainModuleBuilder withReactContext(ReactApplicationContext reactContext) {
+    this.reactContext = reactContext;
+    return this;
+  }
+
+  public KeychainModule build() {
+    validate();
+    return KeychainModule.withWarming(reactContext);
+  }
+
+  private void validate() {
+    if (reactContext == null) {
+      throw new Error("React Context was not provided");
+    }
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/KeychainPackage.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainPackage.java
@@ -14,14 +14,20 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class KeychainPackage implements ReactPackage {
 
-  public KeychainPackage() {
+  private final KeychainModuleBuilder builder;
 
+  public KeychainPackage() {
+    this(new KeychainModuleBuilder());
+  }
+
+  public KeychainPackage(KeychainModuleBuilder builder) {
+    this.builder = builder;
   }
 
   @Override
   @NonNull
   public List<NativeModule> createNativeModules(@NonNull final ReactApplicationContext reactContext) {
-    return Collections.singletonList(KeychainModule.withWarming(reactContext));
+    return Collections.singletonList(builder.withReactContext(reactContext).build());
   }
 
   @NonNull


### PR DESCRIPTION
Added the ability to configure the Android keychain module.
Now it can be created with or without the warmup thread.

Users who want to take advantage of this new way are required to use new constructor with a builder which can be configured as they like:
```java
    private List<ReactPackage> createPackageList() {
      return Arrays.asList(
        ...
        new KeychainPackage(
                new KeychainModuleBuilder()
                        .withoutWarmUp()),
        ...
      )
```

Users who keep using the default constructor will not see any change in behaviour.