### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNKeychain.podspec
+++ b/RNKeychain.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/oblador/react-native-keychain.git", :tag => "v#{s.version}" }
   s.source_files   = 'RNKeychainManager/**/*.{h,m}'
   s.preserve_paths = "**/*.js"
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116