### PR TITLE
Fix Android KeyStore unlock timeouts when using passive biometrics by setting a confirmation step bypass

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -568,7 +568,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
       promptInfoBuilder.setNegativeButtonText(promptInfoNegativeButton);
     }
 
-    /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using Face biometrics */
+    /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using passive biometrics */
     promptInfoBuilder.setConfirmationRequired(false);
 
     final PromptInfo promptInfo = promptInfoBuilder.build();

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -567,6 +567,10 @@ public class KeychainModule extends ReactContextBaseJavaModule {
       String promptInfoNegativeButton = promptInfoOptionsMap.getString(AuthPromptOptions.CANCEL);
       promptInfoBuilder.setNegativeButtonText(promptInfoNegativeButton);
     }
+
+    /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using Face biometrics */
+    promptInfoBuilder.setConfirmationRequired(false);
+
     final PromptInfo promptInfo = promptInfoBuilder.build();
 
     return promptInfo;


### PR DESCRIPTION
**Overview**

This fixes the issue where Android passive (face / iris) biometrics can 'timeout' on the KeyStore unlock between a successful biometric scan and the user selecting the 'Confirm' button.

This issue is seen under issue #318. Under that issue I left a comment here https://github.com/oblador/react-native-keychain/issues/318#issuecomment-735647434

**The Problem**

On Android (using RSA) and when using passive (face / iris) biometrics, the `setUserAuthenticationValidityDurationSeconds` countdown starts as soon as the user successfully completes the biometric face scan. If the user does not press the 'Confirm' button on the Android popup within the set number of seconds in that method (currently set to `5` as of the date of this PR) then the KeyStore is locked again. Once the user selects 'Confirm' after that timeframe the user is presented with a `User not authenticated` error.

**The Solution**

This PR removes the user-driven confirmation step on a *passive* (face or iris) biometrics authentication.

The PR removes the confirmation step by using the [setConfirmationRequired](https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder#setConfirmationRequired(boolean)) API method which defaults to `true`.

Due to the confirm step no longer appearing then there is no chance of a timeout occuring between the user having a successful face / iris scan and the user selecting 'Confirm'. I've only been able to test this against the Pixel 4, which has Android face as its only biometric method, and it works as intended.

Additionally, this brings the library functionality more inline with the iOS behaviour when using Face ID, which also does not require a confirmation step.

**Considerations**

As per the [API documentation](https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder#setConfirmationRequired(boolean)), this is limited to the Android 10 (and above) API but it's also only classed as a 'hint' to the vendor version of Android OS so I don't know how well it's supported across the wider Android ecosystem of devices that will show up supporting passive biometrics.

Now there is no confirmation step it's important for the developers to realise it falls on them to ensure that when biometrics is triggered the user is fully aware that a successful scan will lead to the action being finalised (maybe transaction or purchase, for example).