### PR TITLE
RNKeychainManager set SECURITY_LEVEL safely (Addressing Issue #388)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ import { NativeModules, Platform } from 'react-native';
 const { RNKeychainManager } = NativeModules;
 
 export const SECURITY_LEVEL = Object.freeze({
-  ANY: RNKeychainManager.SECURITY_LEVEL_ANY,
-  SECURE_SOFTWARE: RNKeychainManager.SECURITY_LEVEL_SECURE_SOFTWARE,
-  SECURE_HARDWARE: RNKeychainManager.SECURITY_LEVEL_SECURE_HARDWARE,
+  ANY: RNKeychainManager && RNKeychainManager.SECURITY_LEVEL_ANY,
+  SECURE_SOFTWARE: RNKeychainManager && RNKeychainManager.SECURITY_LEVEL_SECURE_SOFTWARE,
+  SECURE_HARDWARE: RNKeychainManager && RNKeychainManager.SECURITY_LEVEL_SECURE_HARDWARE,
 });
 
 export const ACCESSIBLE = Object.freeze({


### PR DESCRIPTION
This PR addresses the issue in https://github.com/oblador/react-native-keychain/issues/388

It changes three lines in index.js to more safely handle the setting of the `.SECURITY_LEVEL` field for `RNKeychainManager`. This addresses issue that arise when other repos use `react-native-keychain` as a dependency, such as `react-native-pincode`

This PR addresses the error `null is not an object (evaluating 'RNKeychainManager.SECURITY_LEVEL_ANY')` as discussed in the issue above.