### PR TITLE
fix issue in iOS devices with no Biometric hardware returning TouchID

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -306,7 +306,9 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve
         return resolve(kBiometryTypeFaceID);
       }
     }
-    return resolve(kBiometryTypeTouchID);
+    if (context.biometryType == LABiometryTypeTouchID) {
+      return resolve(kBiometryTypeTouchID);
+    }
   }
 
   return resolve([NSNull null]);


### PR DESCRIPTION
For old devices with no TouchID or FaceID calling the getSupportedBiometryType() returns TouchID. Added one more check to rectify the issue.