### PR TITLE
Fixed iOS returning biometry type even when not enrolled.

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -298,7 +298,7 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve
 {
   NSError *aerr = nil;
   LAContext *context = [LAContext new];
-  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&aerr];
+  BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
 
   if (!aerr && canBeProtected) {
     if (@available(iOS 11, *)) {


### PR DESCRIPTION
Makes the following statement from the readme become true:

> ### `getSupportedBiometryType()`
> 
> Get what type of hardware biometry support the device has. Resolves to a `Keychain.BIOMETRY_TYPE` value when supported, otherwise `null`.
> 
> > This method returns `null`, if the device haven't enrolled into fingerprint/FaceId. Even though it has hardware for it.

See issue [#279](https://github.com/oblador/react-native-keychain/issues/279) for more details.

Thanks to [edersonmberti](https://github.com/edersonmberti) for [his fix](https://github.com/oblador/react-native-keychain/issues/279#issuecomment-656734014).