### PR TITLE
Fix biometric retry on OnePlus devices

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -672,12 +672,9 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   /** Get instance of handler that resolves access to the keystore on system request. */
   @NonNull
   protected DecryptionResultHandler getInteractiveHandler(@NonNull final CipherStorage current, @NonNull final PromptInfo promptInfo) {
-    final FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (null == activity) throw new NullPointerException("Not assigned current activity");
-
     ReactApplicationContext reactContext = getReactApplicationContext();
 
-    return DecryptionResultHandlerProvider.getHandler(activity, reactContext, current, promptInfo);
+    return DecryptionResultHandlerProvider.getHandler(reactContext, current, promptInfo);
   }
 
   /** Remove key from old storage and add it to the new storage. */

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.oblador.keychain.SecurityLevel;
+import com.oblador.keychain.decryptionHandler.DecryptionResultHandler;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
@@ -74,32 +75,6 @@ public interface CipherStorage {
       this.key = key;
     }
   }
-
-  /** Get access to the results of decryption via properties. */
-  interface WithResults {
-    /** Get reference on results. */
-    @Nullable
-    DecryptionResult getResult();
-
-    /** Get reference on capture error. */
-    @Nullable
-    Throwable getError();
-
-    /** Block thread and wait for any result of execution. */
-    void waitResult();
-  }
-
-  /** Handler that allows to inject some actions during decrypt operations. */
-  interface DecryptionResultHandler extends WithResults {
-    /** Ask user for interaction, often its unlock of keystore by biometric data providing. */
-    void askAccessPermissions(@NonNull final DecryptionContext context);
-
-    /**
-     *
-     */
-    void onDecrypt(@Nullable final DecryptionResult decryptionResult, @Nullable final Throwable error);
-  }
-  //endregion
 
   //region API
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.AssertionException;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.oblador.keychain.KeychainModule.KnownCiphers;
 import com.oblador.keychain.SecurityLevel;
+import com.oblador.keychain.decryptionHandler.DecryptionResultHandler;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 
 import java.security.GeneralSecurityException;

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 
 import com.oblador.keychain.KeychainModule.KnownCiphers;
 import com.oblador.keychain.SecurityLevel;
+import com.oblador.keychain.decryptionHandler.DecryptionResultHandler;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -9,11 +9,12 @@ import android.security.keystore.UserNotAuthenticatedException;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import com.oblador.keychain.KeychainModule;
 import com.oblador.keychain.SecurityLevel;
+import com.oblador.keychain.decryptionHandler.DecryptionResultHandler;
+import com.oblador.keychain.decryptionHandler.DecryptionResultHandlerNonInteractive;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
@@ -89,7 +90,7 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
                                   @NonNull final SecurityLevel level)
     throws CryptoFailedException {
 
-    final NonInteractiveHandler handler = new NonInteractiveHandler();
+    final DecryptionResultHandlerNonInteractive handler = new DecryptionResultHandlerNonInteractive();
     decrypt(handler, alias, username, password, level);
 
     CryptoFailedException.reThrowOnError(handler.getError());
@@ -256,46 +257,5 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
     return generator.generateKeyPair().getPrivate();
   }
 
-  //endregion
-
-  //region Nested classes
-
-  /** Non interactive handler for decrypting the credentials. */
-  public static class NonInteractiveHandler implements DecryptionResultHandler {
-    private DecryptionResult result;
-    private Throwable error;
-
-    @Override
-    public void askAccessPermissions(@NonNull final DecryptionContext context) {
-      final CryptoFailedException failure = new CryptoFailedException(
-        "Non interactive decryption mode.");
-
-      onDecrypt(null, failure);
-    }
-
-    @Override
-    public void onDecrypt(@Nullable final DecryptionResult decryptionResult,
-                          @Nullable final Throwable error) {
-      this.result = decryptionResult;
-      this.error = error;
-    }
-
-    @Nullable
-    @Override
-    public DecryptionResult getResult() {
-      return result;
-    }
-
-    @Nullable
-    @Override
-    public Throwable getError() {
-      return error;
-    }
-
-    @Override
-    public void waitResult() {
-      /* do nothing, expected synchronized call in one thread */
-    }
-  }
   //endregion
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
@@ -1,0 +1,29 @@
+package com.oblador.keychain.decryptionHandler;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
+
+/** Handler that allows to inject some actions during decrypt operations. */
+public interface DecryptionResultHandler {
+  /** Ask user for interaction, often its unlock of keystore by biometric data providing. */
+  void askAccessPermissions(@NonNull final DecryptionContext context);
+
+  /**
+   *
+   */
+  void onDecrypt(@Nullable final DecryptionResult decryptionResult, @Nullable final Throwable error);
+
+  /** Get reference on results. */
+  @Nullable
+  DecryptionResult getResult();
+
+  /** Get reference on capture error. */
+  @Nullable
+  Throwable getError();
+
+  /** Block thread and wait for any result of execution. */
+  void waitResult();
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Executors;
 public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt.AuthenticationCallback implements DecryptionResultHandler {
   protected CipherStorage.DecryptionResult result;
   protected Throwable error;
-  protected final FragmentActivity activity;
+  protected FragmentActivity activity;
   protected final ReactApplicationContext reactContext;
   protected final CipherStorageBase storage;
   protected final Executor executor = Executors.newSingleThreadExecutor();
@@ -33,11 +33,10 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
   /** Logging tag. */
   protected static final String LOG_TAG = DecryptionResultHandlerInteractiveBiometric.class.getSimpleName();
 
-  public DecryptionResultHandlerInteractiveBiometric(@NonNull final FragmentActivity activity,
+  public DecryptionResultHandlerInteractiveBiometric(
                                                      @NonNull ReactApplicationContext reactContext,
                                                      @NonNull final CipherStorage storage,
                                                      @NonNull final BiometricPrompt.PromptInfo promptInfo) {
-    this.activity = activity;
     this.reactContext = reactContext;
     this.storage = (CipherStorageBase) storage;
     this.promptInfo = promptInfo;
@@ -106,6 +105,8 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
 
   /** trigger interactive authentication. */
   public void startAuthentication() {
+    FragmentActivity activity = getCurrentActivity();
+
     // code can be executed only from MAIN thread
     if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
       activity.runOnUiThread(this::startAuthentication);
@@ -113,10 +114,17 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
       return;
     }
 
-    authenticateWithPrompt();
+    authenticateWithPrompt(activity);
   }
 
-  protected BiometricPrompt authenticateWithPrompt() {
+  protected FragmentActivity getCurrentActivity() {
+    final FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
+    if (null == activity) throw new NullPointerException("Not assigned current activity");
+
+    return activity;
+  }
+
+  protected BiometricPrompt authenticateWithPrompt(@NonNull final FragmentActivity activity) {
     final BiometricPrompt prompt = new BiometricPrompt(activity, executor, this);
     prompt.authenticate(this.promptInfo);
 

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt.AuthenticationCallback implements DecryptionResultHandler {
   protected CipherStorage.DecryptionResult result;
   protected Throwable error;
-  protected FragmentActivity activity;
   protected final ReactApplicationContext reactContext;
   protected final CipherStorageBase storage;
   protected final Executor executor = Executors.newSingleThreadExecutor();

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
@@ -1,0 +1,144 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.AssertionException;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.DeviceAvailability;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
+import com.oblador.keychain.cipherStorage.CipherStorageBase;
+import com.oblador.keychain.exceptions.CryptoFailedException;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt.AuthenticationCallback implements DecryptionResultHandler {
+  protected CipherStorage.DecryptionResult result;
+  protected Throwable error;
+  protected final FragmentActivity activity;
+  protected final ReactApplicationContext reactContext;
+  protected final CipherStorageBase storage;
+  protected final Executor executor = Executors.newSingleThreadExecutor();
+  protected CipherStorage.DecryptionContext context;
+  protected BiometricPrompt.PromptInfo promptInfo;
+
+  /** Logging tag. */
+  protected static final String LOG_TAG = DecryptionResultHandlerInteractiveBiometric.class.getSimpleName();
+
+  public DecryptionResultHandlerInteractiveBiometric(@NonNull final FragmentActivity activity,
+                                                     @NonNull ReactApplicationContext reactContext,
+                                                     @NonNull final CipherStorage storage,
+                                                     @NonNull final BiometricPrompt.PromptInfo promptInfo) {
+    this.activity = activity;
+    this.reactContext = reactContext;
+    this.storage = (CipherStorageBase) storage;
+    this.promptInfo = promptInfo;
+  }
+
+  @Override
+  public void askAccessPermissions(@NonNull final DecryptionContext context) {
+    this.context = context;
+
+    if (!DeviceAvailability.isPermissionsGranted(reactContext)) {
+      final CryptoFailedException failure = new CryptoFailedException(
+        "Could not start fingerprint Authentication. No permissions granted.");
+
+      onDecrypt(null, failure);
+    } else {
+      startAuthentication();
+    }
+  }
+
+  @Override
+  public void onDecrypt(@Nullable final DecryptionResult decryptionResult, @Nullable final Throwable error) {
+    this.result = decryptionResult;
+    this.error = error;
+
+    synchronized (this) {
+      notifyAll();
+    }
+  }
+
+  @Nullable
+  @Override
+  public CipherStorage.DecryptionResult getResult() {
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public Throwable getError() {
+    return error;
+  }
+
+  /** Called when an unrecoverable error has been encountered and the operation is complete. */
+  @Override
+  public void onAuthenticationError(final int errorCode, @NonNull final CharSequence errString) {
+    final CryptoFailedException error = new CryptoFailedException("code: " + errorCode + ", msg: " + errString);
+
+    onDecrypt(null, error);
+  }
+
+  /** Called when a biometric is recognized. */
+  @Override
+  public void onAuthenticationSucceeded(@NonNull final BiometricPrompt.AuthenticationResult result) {
+    try {
+      if (null == context) throw new NullPointerException("Decrypt context is not assigned yet.");
+
+      final CipherStorage.DecryptionResult decrypted = new CipherStorage.DecryptionResult(
+        storage.decryptBytes(context.key, context.username),
+        storage.decryptBytes(context.key, context.password)
+      );
+
+      onDecrypt(decrypted, null);
+    } catch (Throwable fail) {
+      onDecrypt(null, fail);
+    }
+  }
+
+  /** trigger interactive authentication. */
+  public void startAuthentication() {
+    // code can be executed only from MAIN thread
+    if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
+      activity.runOnUiThread(this::startAuthentication);
+      waitResult();
+      return;
+    }
+
+    authenticateWithPrompt();
+  }
+
+  protected BiometricPrompt authenticateWithPrompt() {
+    final BiometricPrompt prompt = new BiometricPrompt(activity, executor, this);
+    prompt.authenticate(this.promptInfo);
+
+    return prompt;
+  }
+
+  /** Block current NON-main thread and wait for user authentication results. */
+  @Override
+  public void waitResult() {
+    if (Thread.currentThread() == Looper.getMainLooper().getThread())
+      throw new AssertionException("method should not be executed from MAIN thread");
+
+    Log.i(LOG_TAG, "blocking thread. waiting for done UI operation.");
+
+    try {
+      synchronized (this) {
+        wait();
+      }
+    } catch (InterruptedException ignored) {
+      /* shutdown sequence */
+    }
+
+    Log.i(LOG_TAG, "unblocking thread.");
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
@@ -14,11 +14,10 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
   private BiometricPrompt presentedPrompt;
   private Boolean didFailBiometric = false;
 
-  public DecryptionResultHandlerInteractiveBiometricManualRetry(@NonNull FragmentActivity activity,
-                                                                @NonNull ReactApplicationContext reactContext,
+  public DecryptionResultHandlerInteractiveBiometricManualRetry(@NonNull ReactApplicationContext reactContext,
                                                                 @NonNull CipherStorage storage,
                                                                 @NonNull BiometricPrompt.PromptInfo promptInfo) {
-    super(activity, reactContext, storage, promptInfo);
+    super(reactContext, storage, promptInfo);
   }
 
   /** Manually cancel current (invisible) authentication to clear the fragment. */
@@ -72,6 +71,8 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
   /** trigger interactive authentication. */
   @Override
   public void startAuthentication() {
+    FragmentActivity activity = getCurrentActivity();
+
     // code can be executed only from MAIN thread
     if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
       activity.runOnUiThread(this::startAuthentication);
@@ -79,12 +80,15 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
       return;
     }
 
-    this.presentedPrompt = authenticateWithPrompt();
+    this.presentedPrompt = authenticateWithPrompt(activity);
   }
 
   /** trigger interactive authentication without invoking another waitResult() */
   private void retryAuthentication() {
     Log.d(LOG_TAG, "Retrying biometric authentication.");
+
+    FragmentActivity activity = getCurrentActivity();
+
     if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
       try {
         /*
@@ -100,6 +104,6 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
       return;
     }
 
-    this.presentedPrompt = authenticateWithPrompt();
+    this.presentedPrompt = authenticateWithPrompt(activity);
   }
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
@@ -1,0 +1,105 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+public class DecryptionResultHandlerInteractiveBiometricManualRetry extends DecryptionResultHandlerInteractiveBiometric implements DecryptionResultHandler {
+  private BiometricPrompt presentedPrompt;
+  private Boolean didFailBiometric = false;
+
+  public DecryptionResultHandlerInteractiveBiometricManualRetry(@NonNull FragmentActivity activity,
+                                                                @NonNull ReactApplicationContext reactContext,
+                                                                @NonNull CipherStorage storage,
+                                                                @NonNull BiometricPrompt.PromptInfo promptInfo) {
+    super(activity, reactContext, storage, promptInfo);
+  }
+
+  /** Manually cancel current (invisible) authentication to clear the fragment. */
+  private void cancelPresentedAuthentication() {
+    Log.d(LOG_TAG, "Cancelling authentication");
+    if (presentedPrompt == null) {
+      return;
+    }
+
+    try {
+      presentedPrompt.cancelAuthentication();
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      this.presentedPrompt = null;
+    }
+  }
+
+  /** Called when an unrecoverable error has been encountered and the operation is complete. */
+  @Override
+  public void onAuthenticationError(final int errorCode, @NonNull final CharSequence errString) {
+    if (didFailBiometric) {
+      this.presentedPrompt = null;
+      this.didFailBiometric = false;
+      retryAuthentication();
+      return;
+    }
+
+    super.onAuthenticationError(errorCode, errString);
+  }
+
+  /** Called when a biometric (e.g. fingerprint, face, etc.) is presented but not recognized as belonging to the user. */
+  @Override
+  public void onAuthenticationFailed() {
+    Log.d(LOG_TAG, "Authentication failed: biometric not recognized. " + (presentedPrompt == null));
+    if (presentedPrompt != null) {
+      this.didFailBiometric = true;
+      cancelPresentedAuthentication();
+    }
+  }
+
+  /** Called when a biometric is recognized. */
+  @Override
+  public void onAuthenticationSucceeded(@NonNull final BiometricPrompt.AuthenticationResult result) {
+    this.presentedPrompt = null;
+    this.didFailBiometric = false;
+
+    super.onAuthenticationSucceeded(result);
+  }
+
+  /** trigger interactive authentication. */
+  @Override
+  public void startAuthentication() {
+    // code can be executed only from MAIN thread
+    if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
+      activity.runOnUiThread(this::startAuthentication);
+      waitResult();
+      return;
+    }
+
+    this.presentedPrompt = authenticateWithPrompt();
+  }
+
+  /** trigger interactive authentication without invoking another waitResult() */
+  private void retryAuthentication() {
+    Log.d(LOG_TAG, "Retrying biometric authentication.");
+    if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
+      try {
+        /*
+         * NOTE: Applications should not cancel and authenticate in a short succession
+         * Waiting 100ms in a non-UI thread to make sure previous BiometricPrompt is cleared by OS
+         */
+        Thread.sleep(100);
+      } catch (InterruptedException ignored) {
+        /* shutdown sequence */
+      }
+
+      activity.runOnUiThread(this::retryAuthentication);
+      return;
+    }
+
+    this.presentedPrompt = authenticateWithPrompt();
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
@@ -53,7 +53,7 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
   /** Called when a biometric (e.g. fingerprint, face, etc.) is presented but not recognized as belonging to the user. */
   @Override
   public void onAuthenticationFailed() {
-    Log.d(LOG_TAG, "Authentication failed: biometric not recognized. " + (presentedPrompt == null));
+    Log.d(LOG_TAG, "Authentication failed: biometric not recognized.");
     if (presentedPrompt != null) {
       this.didFailBiometric = true;
       cancelPresentedAuthentication();

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
@@ -84,7 +84,7 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
   }
 
   /** trigger interactive authentication without invoking another waitResult() */
-  private void retryAuthentication() {
+  protected void retryAuthentication() {
     Log.d(LOG_TAG, "Retrying biometric authentication.");
 
     FragmentActivity activity = getCurrentActivity();

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
@@ -1,0 +1,45 @@
+package com.oblador.keychain.decryptionHandler;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
+import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
+import com.oblador.keychain.exceptions.CryptoFailedException;
+
+public class DecryptionResultHandlerNonInteractive implements DecryptionResultHandler {
+  private DecryptionResult result;
+  private Throwable error;
+
+  @Override
+  public void askAccessPermissions(@NonNull final DecryptionContext context) {
+    final CryptoFailedException failure = new CryptoFailedException(
+      "Non interactive decryption mode.");
+
+    onDecrypt(null, failure);
+  }
+
+  @Override
+  public void onDecrypt(@Nullable final DecryptionResult decryptionResult,
+                        @Nullable final Throwable error) {
+    this.result = decryptionResult;
+    this.error = error;
+  }
+
+  @Nullable
+  @Override
+  public DecryptionResult getResult() {
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public Throwable getError() {
+    return error;
+  }
+
+  @Override
+  public void waitResult() {
+    /* do nothing, expected synchronized call in one thread */
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
@@ -1,0 +1,48 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+import java.util.Arrays;
+
+// NOTE: the logic for handling OnePlus bug is taken from the following forum post:
+// https://forums.oneplus.com/threads/oneplus-7-pro-fingerprint-biometricprompt-does-not-show.1035821/#post-21710422
+public class DecryptionResultHandlerProvider {
+  private static final String ONE_PLUS_BRAND = "oneplus";
+  private static final String[] ONE_PLUS_MODELS_WITHOUT_BIOMETRIC_BUG = {
+    "A0001", // OnePlus One
+    "ONE A2001", "ONE A2003", "ONE A2005", // OnePlus 2
+    "ONE E1001", "ONE E1003", "ONE E1005", // OnePlus X
+    "ONEPLUS A3000", "ONEPLUS SM-A3000", "ONEPLUS A3003", // OnePlus 3
+    "ONEPLUS A3010", // OnePlus 3T
+    "ONEPLUS A5000", // OnePlus 5
+    "ONEPLUS A5010", // OnePlus 5T
+    "ONEPLUS A6000", "ONEPLUS A6003" // OnePlus 6
+  };
+
+  private static boolean hasOnePlusBiometricBug() {
+    return Build.BRAND.toLowerCase().equals(ONE_PLUS_BRAND) &&
+      !Arrays.asList(ONE_PLUS_MODELS_WITHOUT_BIOMETRIC_BUG).contains(Build.MODEL);
+  }
+
+  public static DecryptionResultHandler getHandler(@NonNull final FragmentActivity activity,
+                                                   @NonNull ReactApplicationContext reactContext,
+                                                   @NonNull final CipherStorage storage,
+                                                   @NonNull final BiometricPrompt.PromptInfo promptInfo) {
+    if (storage.isBiometrySupported()) {
+      if (hasOnePlusBiometricBug()) {
+        return new DecryptionResultHandlerInteractiveBiometricManualRetry(activity, reactContext, storage, promptInfo);
+      }
+
+      return new DecryptionResultHandlerInteractiveBiometric(activity, reactContext, storage, promptInfo);
+    }
+
+    return new DecryptionResultHandlerNonInteractive();
+  }
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
@@ -4,7 +4,6 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.biometric.BiometricPrompt;
-import androidx.fragment.app.FragmentActivity;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.oblador.keychain.cipherStorage.CipherStorage;

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProvider.java
@@ -31,16 +31,15 @@ public class DecryptionResultHandlerProvider {
       !Arrays.asList(ONE_PLUS_MODELS_WITHOUT_BIOMETRIC_BUG).contains(Build.MODEL);
   }
 
-  public static DecryptionResultHandler getHandler(@NonNull final FragmentActivity activity,
-                                                   @NonNull ReactApplicationContext reactContext,
+  public static DecryptionResultHandler getHandler(@NonNull ReactApplicationContext reactContext,
                                                    @NonNull final CipherStorage storage,
                                                    @NonNull final BiometricPrompt.PromptInfo promptInfo) {
     if (storage.isBiometrySupported()) {
       if (hasOnePlusBiometricBug()) {
-        return new DecryptionResultHandlerInteractiveBiometricManualRetry(activity, reactContext, storage, promptInfo);
+        return new DecryptionResultHandlerInteractiveBiometricManualRetry(reactContext, storage, promptInfo);
       }
 
-      return new DecryptionResultHandlerInteractiveBiometric(activity, reactContext, storage, promptInfo);
+      return new DecryptionResultHandlerInteractiveBiometric(reactContext, storage, promptInfo);
     }
 
     return new DecryptionResultHandlerNonInteractive();

--- a/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
+++ b/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
@@ -150,6 +150,7 @@ public class KeychainModuleTests {
     //   Fingerprints are configured
     //   fingerprint feature is ignored by android os
     ReactApplicationContext context = getRNContext();
+    shadowOf(context.getPackageManager()).setSystemFeature(PackageManager.FEATURE_FINGERPRINT, true);
 
     // set that hardware is available
     FingerprintManager fm = (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
@@ -240,6 +241,7 @@ public class KeychainModuleTests {
     //   API23 android version
     //   fingerprints configured
     final ReactApplicationContext context = getRNContext();
+    shadowOf(context.getPackageManager()).setSystemFeature(PackageManager.FEATURE_FINGERPRINT, true);
 
     // set that hardware is available and fingerprints configured
     final FingerprintManager fm = (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
@@ -447,6 +449,11 @@ public class KeychainModuleTests {
     final Promise mockPromise = mock(Promise.class);
     final JavaOnlyMap options = new JavaOnlyMap();
     options.putString(Maps.SERVICE, "dummy");
+
+    final JavaOnlyMap promptOptions = new JavaOnlyMap();
+    promptOptions.putString(KeychainModule.AuthPromptOptions.TITLE, "Title");
+    promptOptions.putString(KeychainModule.AuthPromptOptions.CANCEL, "Cancel");
+    options.putMap(Maps.AUTH_PROMPT, promptOptions);
 
     // store record done with RSA/Biometric cipher
     prefs.storeEncryptedEntry("dummy", result);

--- a/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetryTest.java
+++ b/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetryTest.java
@@ -1,0 +1,116 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.Manifest;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.os.Build;
+
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+import com.oblador.keychain.cipherStorage.CipherStorageBase;
+import com.oblador.keychain.cipherStorage.CipherStorageKeystoreRsaEcb;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static androidx.biometric.BiometricConstants.ERROR_USER_CANCELED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class DecryptionResultHandlerInteractiveBiometricManualRetryTest {
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryNotRecognized() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final FragmentActivity mockActivity = mock(FragmentActivity.class);
+
+    final BiometricPrompt mockBiometricPrompt = mock(BiometricPrompt.class);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+    when(mockContext.getCurrentActivity()).thenReturn(mockActivity);
+
+    final CipherStorageBase storage = mock(CipherStorageKeystoreRsaEcb.class);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final BiometricPrompt.AuthenticationResult mockAuthResult = mock(BiometricPrompt.AuthenticationResult.class);
+
+    DecryptionResultHandlerInteractiveBiometricManualRetry handler = new DecryptionResultHandlerInteractiveBiometricManualRetry(mockContext, storage, promptInfo);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometricManualRetry spy = spy(handler);
+    doReturn(mockBiometricPrompt).when(spy).authenticateWithPrompt(mockActivity);
+    // Do not retry
+    doNothing().when(spy).retryAuthentication();
+
+    spy.startAuthentication();
+    spy.onAuthenticationFailed();
+
+    //THEN
+    verify(mockBiometricPrompt, times(1)).cancelAuthentication();
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryNotRecognizedWithRetry() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final FragmentActivity mockActivity = mock(FragmentActivity.class);
+
+    final BiometricPrompt mockBiometricPrompt = mock(BiometricPrompt.class);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+    when(mockContext.getCurrentActivity()).thenReturn(mockActivity);
+
+    final CipherStorageBase storage = mock(CipherStorageKeystoreRsaEcb.class);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final BiometricPrompt.AuthenticationResult mockAuthResult = mock(BiometricPrompt.AuthenticationResult.class);
+
+    DecryptionResultHandlerInteractiveBiometricManualRetry handler = new DecryptionResultHandlerInteractiveBiometricManualRetry(mockContext, storage, promptInfo);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometricManualRetry spy = spy(handler);
+    doReturn(mockBiometricPrompt).when(spy).authenticateWithPrompt(mockActivity);
+
+    spy.startAuthentication();
+    spy.onAuthenticationFailed();
+    spy.onAuthenticationError(ERROR_USER_CANCELED, "Authentication cancelled.");
+
+    //THEN
+    verify(mockBiometricPrompt, times(1)).cancelAuthentication();
+    verify(spy, times(2)).authenticateWithPrompt(mockActivity);
+
+    assertThat(spy.getResult(), is(nullValue()));
+    assertThat(spy.getError(), is(nullValue()));
+  }
+}

--- a/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricTest.java
+++ b/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricTest.java
@@ -1,0 +1,176 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.Manifest;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.os.Build;
+
+import androidx.biometric.BiometricPrompt;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+import com.oblador.keychain.cipherStorage.CipherStorageBase;
+import com.oblador.keychain.cipherStorage.CipherStorageKeystoreRsaEcb;
+import com.oblador.keychain.exceptions.CryptoFailedException;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static androidx.biometric.BiometricConstants.ERROR_USER_CANCELED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class DecryptionResultHandlerInteractiveBiometricTest {
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryNotPermitted() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(false);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+
+    final CipherStorage storage = mock(CipherStorageBase.class);
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final CipherStorage.DecryptionContext decryptionContext = mock(CipherStorage.DecryptionContext.class);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometric handler = new DecryptionResultHandlerInteractiveBiometric(mockContext, storage, promptInfo);
+    handler.askAccessPermissions(decryptionContext);
+
+    //THEN
+    assertThat(handler.getResult(), is(nullValue()));
+    assertThat(handler.getError(), Matchers.instanceOf(CryptoFailedException.class));
+  }
+
+  @Test(expected= NullPointerException.class)
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryAuthenticationErrorNoActivity() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+
+    final CipherStorage storage = mock(CipherStorageBase.class);
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final CipherStorage.DecryptionContext decryptionContext = mock(CipherStorage.DecryptionContext.class);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometric handler = new DecryptionResultHandlerInteractiveBiometric(mockContext, storage, promptInfo);
+    handler.askAccessPermissions(decryptionContext);
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryAuthenticationCancelled() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+
+    final CipherStorage storage = mock(CipherStorageBase.class);
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometric handler = new DecryptionResultHandlerInteractiveBiometric(mockContext, storage, promptInfo);
+    handler.onAuthenticationError(ERROR_USER_CANCELED, "Authentication cancelled.");
+
+    //THEN
+    assertThat(handler.getResult(), is(nullValue()));
+    assertThat(handler.getError(), Matchers.instanceOf(CryptoFailedException.class));
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryAuthenticationSuccessfulNoContext() {
+    // GIVEN
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+
+    final CipherStorageBase storage = mock(CipherStorageBase.class);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final BiometricPrompt.AuthenticationResult mockAuthResult = mock(BiometricPrompt.AuthenticationResult.class);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometric handler = new DecryptionResultHandlerInteractiveBiometric(mockContext, storage, promptInfo);
+    handler.onAuthenticationSucceeded(mockAuthResult);
+
+    //THEN
+    assertThat(handler.getResult(), is(nullValue()));
+    assertThat(handler.getError(), Matchers.instanceOf(NullPointerException.class));
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryAuthenticationSuccessful() throws IOException, GeneralSecurityException {
+    // GIVEN
+    final String keyAlias = "key";
+    final Key key = null;
+    final String decryptedUsername = "username";
+    final String decryptedPassword = "password";
+    final byte[] username = decryptedUsername.getBytes();
+    final byte[] password = decryptedPassword.getBytes();
+    final CipherStorage.DecryptionContext decryptionContext = new CipherStorage.DecryptionContext(
+      keyAlias, key, password, username);
+
+    final KeyguardManager keyguardManager = mock(KeyguardManager.class);
+    when(keyguardManager.isKeyguardSecure()).thenReturn(true);
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(keyguardManager);
+    when(mockContext.checkSelfPermission(Manifest.permission.USE_FINGERPRINT)).thenReturn(PERMISSION_GRANTED);
+
+    final CipherStorageBase storage = mock(CipherStorageKeystoreRsaEcb.class);
+    when(storage.decryptBytes(key, username)).thenReturn(decryptedUsername);
+    when(storage.decryptBytes(key, password)).thenReturn(decryptedPassword);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+    final BiometricPrompt.AuthenticationResult mockAuthResult = mock(BiometricPrompt.AuthenticationResult.class);
+
+    DecryptionResultHandlerInteractiveBiometric handler = new DecryptionResultHandlerInteractiveBiometric(mockContext, storage, promptInfo);
+
+    // WHEN
+    DecryptionResultHandlerInteractiveBiometric spy = spy(handler);
+    // Can't mock BiometricPrompt stack at the moment
+    doNothing().when(spy).startAuthentication();
+
+    spy.askAccessPermissions(decryptionContext);
+    spy.onAuthenticationSucceeded(mockAuthResult);
+
+    //THEN
+    CipherStorage.DecryptionResult result = spy.getResult();
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.username, is(decryptedUsername));
+    assertThat(result.password, is(decryptedPassword));
+    assertThat(spy.getError(), is(nullValue()));
+  }
+}

--- a/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProviderTest.java
+++ b/android/src/test/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerProviderTest.java
@@ -1,0 +1,81 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.os.Build;
+
+import androidx.biometric.BiometricPrompt;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.oblador.keychain.cipherStorage.CipherStorage;
+import com.oblador.keychain.cipherStorage.CipherStorageBase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class DecryptionResultHandlerProviderTest {
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryNotSupported() {
+    // GIVEN
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    final CipherStorage storage = mock(CipherStorage.class);
+    when(storage.isBiometrySupported()).thenReturn(false);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+
+    // WHEN
+    DecryptionResultHandler handler = DecryptionResultHandlerProvider.getHandler(mockContext, storage, promptInfo);
+
+    //THEN
+    assertThat(handler, instanceOf(DecryptionResultHandlerNonInteractive.class));
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryWithOnePlusBug() {
+    // GIVEN
+    ReflectionHelpers.setStaticField(android.os.Build.class, "BRAND", "OnePlus");
+    ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "ONEPLUS A6010"); // OnePlus 6T
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    final CipherStorage storage = mock(CipherStorageBase.class);
+    when(storage.isBiometrySupported()).thenReturn(true);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+
+    // WHEN
+    DecryptionResultHandler handler = DecryptionResultHandlerProvider.getHandler(mockContext, storage, promptInfo);
+
+    //THEN
+    assertThat(handler, instanceOf(DecryptionResultHandlerInteractiveBiometricManualRetry.class));
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.M)
+  public void testBiometryWithoutBug() {
+    // GIVEN
+    ReflectionHelpers.setStaticField(android.os.Build.class, "BRAND", "OnePlus");
+    ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "ONEPLUS A6000"); // OnePlus 6
+
+    final ReactApplicationContext mockContext = mock(ReactApplicationContext.class);
+    final CipherStorage storage = mock(CipherStorageBase.class);
+    when(storage.isBiometrySupported()).thenReturn(true);
+
+    final BiometricPrompt.PromptInfo promptInfo = mock(BiometricPrompt.PromptInfo.class);
+
+    // WHEN
+    DecryptionResultHandler handler = DecryptionResultHandlerProvider.getHandler(mockContext, storage, promptInfo);
+
+    //THEN
+    assertThat(handler, instanceOf(DecryptionResultHandlerInteractiveBiometric.class));
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
       }
 
       when ("${requested.group}:${requested.name}") {
-        "com.facebook.react:react-native" -> useVersion("0.61.2")
+        "com.facebook.react:react-native" -> useVersion("0.63.4")
         "com.facebook.soloader:soloader" -> useVersion("0.6.+")
       }
     }


### PR DESCRIPTION
Fixes #446 
Fixes #335 
This change addresses the issue with biometric retry on OnePlus devices. The main approach is taken from the incredible investigation done by the user in [this forum post](https://forums.oneplus.com/threads/oneplus-7-pro-fingerprint-biometricprompt-does-not-show.1035821/#post-21710422).

The idea is to call `BiometricPrompt.cancelAuthentication()` after each `onAuthenticationFailed` received. After manual cleanup, the biometric auth is retried (without creating a new `waitForResult` block). When the user runs out of retries the flow completes gradually in `onAuthenticationError` which throws `CryptoFailedException`.

I verified this solution on my OnePlus 6T running OxygenOS 10.

**TODO**
- [x] Add unit tests

## Retrying until sensor is disabled (too many attempts)
![fixed_retry_too_many_attempts](https://user-images.githubusercontent.com/2971261/111076616-51d59700-84ed-11eb-8474-2a4ad145c8bf.gif)

## Retrying once with following success
![fixed_retry_success](https://user-images.githubusercontent.com/2971261/111076610-4edaa680-84ed-11eb-8110-9b333af33df7.gif)