### PR TITLE
Optimized getCipherStorageForCurrentAPILevel method

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -728,19 +728,20 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     for (CipherStorage variant : cipherStorageMap.values()) {
       Log.d(KEYCHAIN_MODULE, "Probe cipher storage: " + variant.getClass().getSimpleName());
 
+      // if biometric supported but not configured properly than skip
+      if (variant.isBiometrySupported() && !isBiometry) continue;
+
       // Is the cipherStorage supported on the current API level?
       final int minApiLevel = variant.getMinSupportedApiLevel();
-      final int capabilityLevel = variant.getCapabilityLevel();
       final boolean isSupportedApi = (minApiLevel <= currentApiLevel);
 
       // API not supported
       if (!isSupportedApi) continue;
 
+      final int capabilityLevel = variant.getCapabilityLevel();
+
       // Is the API level better than the one we previously selected (if any)?
       if (foundCipher != null && capabilityLevel < foundCipher.getCapabilityLevel()) continue;
-
-      // if biometric supported but not configured properly than skip
-      if (variant.isBiometrySupported() && !isBiometry) continue;
 
       // remember storage with the best capabilities
       foundCipher = variant;


### PR DESCRIPTION
 reordered the execution of the instructions to optimize the getCipherStorageForCurrentAPILevel method.

In the case of isBiometry = false it is useless to execute the getCapabilityLevel method which can be calculated in case the RSA private key is missing.

I realized this because not using the warm up, the first de-encryption was still very slow due to this particular.

Furthermore, this re-order does not cause problems for the warm up because it is valued there with isBiometry = true.