### PR TITLE
Remove deprecated kSecAttrAccessibleAlwaysThisDeviceOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ Refs:
 | **`WHEN_PASSCODE_SET_THIS_DEVICE_ONLY`**  | The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device. Items with this attribute never migrate to a new device. |
 | **`WHEN_UNLOCKED_THIS_DEVICE_ONLY`**      | The data in the keychain item can be accessed only while the device is unlocked by the user. Items with this attribute do not migrate to a new device.                                 |
 | **`AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`** | The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user. Items with this attribute never migrate to a new device.         |
-| **`ALWAYS_THIS_DEVICE_ONLY`**             | The data in the keychain item can always be accessed regardless of whether the device is locked. Items with this attribute never migrate to a new device.                              |
 
 Refs:
 

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -101,8 +101,7 @@ CFStringRef accessibleValue(NSDictionary *options)
       @"AccessibleAlways": (__bridge NSString *)kSecAttrAccessibleAlways,
       @"AccessibleWhenPasscodeSetThisDeviceOnly": (__bridge NSString *)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
       @"AccessibleWhenUnlockedThisDeviceOnly": (__bridge NSString *)kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-      @"AccessibleAfterFirstUnlockThisDeviceOnly": (__bridge NSString *)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-      @"AccessibleAlwaysThisDeviceOnly": (__bridge NSString *)kSecAttrAccessibleAlwaysThisDeviceOnly
+      @"AccessibleAfterFirstUnlockThisDeviceOnly": (__bridge NSString *)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
     };
     NSString *result = keyMap[options[@"accessible"]];
     if (result) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ export const ACCESSIBLE = Object.freeze({
   WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'AccessibleWhenUnlockedThisDeviceOnly',
   AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY:
     'AccessibleAfterFirstUnlockThisDeviceOnly',
-  ALWAYS_THIS_DEVICE_ONLY: 'AccessibleAlwaysThisDeviceOnly',
 });
 
 export const ACCESS_CONTROL = Object.freeze({

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -20,7 +20,6 @@ declare module 'react-native-keychain' {
     WHEN_PASSCODE_SET_THIS_DEVICE_ONLY = 'AccessibleWhenPasscodeSetThisDeviceOnly',
     WHEN_UNLOCKED_THIS_DEVICE_ONLY = 'AccessibleWhenUnlockedThisDeviceOnly',
     AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY = 'AccessibleAfterFirstUnlockThisDeviceOnly',
-    ALWAYS_THIS_DEVICE_ONLY = 'AccessibleAlwaysThisDeviceOnly',
   }
 
   export enum ACCESS_CONTROL {


### PR DESCRIPTION
This has been deprecated since iOS 13

https://developer.apple.com/documentation/security/ksecattraccessiblealwaysthisdeviceonly?language=objc


Apple docs currently mention: `This is not recommended for application use`