### PR TITLE
Update index.js fix getAllGenericPasswordServices undefined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ export function resetGenericPassword(
  * Gets all `service` keys used in keychain entries.
  * @return {Promise} Resolves to an array of strings
  */
-export async function getAllGenericPasswordServices(): Promise<string[]> {
+export function getAllGenericPasswordServices(): Promise<string[]> {
   return RNKeychainManager.getAllGenericPasswordServices();
 }
 


### PR DESCRIPTION
Removed async from getAllGenericPasswordServices to fix 
```
 ERROR  Could not get all keys. TypeError: ReactNativeKeychain.getAllGenericPasswordServices is not a function. (In 'ReactNativeKeychain.getAllGenericPasswordServices()', 'ReactNativeKeychain.getAllGenericPasswordServices' is undefined)
```