### PR TITLE
use authenticationPrompt in getInternetCredentialsForServer

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -297,7 +297,7 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
       }
     }
   }
-  
+
   return services;
 }
 
@@ -478,12 +478,14 @@ RCT_EXPORT_METHOD(getInternetCredentialsForServer:(NSString *)server
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+  NSString *authenticationPrompt = authenticationPromptValue(options);
   NSDictionary *query = @{
     (__bridge NSString *)kSecClass: (__bridge id)(kSecClassInternetPassword),
     (__bridge NSString *)kSecAttrServer: server,
     (__bridge NSString *)kSecReturnAttributes: (__bridge id)kCFBooleanTrue,
     (__bridge NSString *)kSecReturnData: (__bridge id)kCFBooleanTrue,
     (__bridge NSString *)kSecMatchLimit: (__bridge NSString *)kSecMatchLimitOne
+    (__bridge NSString *)kSecUseOperationPrompt: authenticationPrompt
   };
 
   // Look up server in the keychain


### PR DESCRIPTION
This issue can be found only on iOS, android works as expected.
It seems like `authenticationPrompt` option is only working for `getGenericPassword`, contrary to the docs in README.md. 
This fix allows the use of the  `authenticationPrompt` option for `getInternetCredentialsForServer`

There is also an issue opened for this two years ago: https://github.com/oblador/react-native-keychain/issues/201

*Testing*
The following snippet should add a description text to the biometrics prompt
```
import Keychain from "react-native-keychain";

Keychain.setInternetCredentials('server', 'user', 'pass', {
  accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY
}).then(async () => {
  await Keychain.getInternetCredentials('server', {
    authenticationPrompt: {
      title: 'Place your finger on the home button to login',
    },
  });
});
```
![image](https://user-images.githubusercontent.com/1008662/120229392-b7683280-c255-11eb-9e00-cc476c1afcb5.png)
