### PR TITLE
Adds getAllInternetPasswordServers method for iOS

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -320,8 +320,11 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
     result = (__bridge NSArray*)(resultRef);
     if (result != NULL) {
       for (id entry in result) {
-        NSString *server = [entry objectForKey:(__bridge NSString *)kSecAttrServer];
-        [servers addObject:server];
+        NSMutableData *serverData = [entry objectForKey:(__bridge NSString *)kSecAttrServer];
+        if (serverData != NULL) {
+          NSString *server = [[NSString alloc] initWithData:serverData encoding:NSUTF8StringEncoding];
+          [servers addObject:server];
+        }
       }
     }
   }

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -301,6 +301,34 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
   return services;
 }
 
+-(NSArray<NSString*>*)getAllServersForInternetPasswords
+{
+  NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                (__bridge id)kCFBooleanTrue, (__bridge id)kSecReturnAttributes,
+                                (__bridge id)kSecMatchLimitAll, (__bridge id)kSecMatchLimit,
+                                nil];
+  NSMutableArray<NSString*> *servers = [NSMutableArray<NSString*> new];
+
+  [query setObject:(__bridge id)kSecClassInternetPassword forKey:(__bridge id)kSecClass];
+  NSArray *result = nil;
+  CFTypeRef resultRef = NULL;
+  OSStatus osStatus = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef*)&resultRef);
+  if (osStatus != noErr && osStatus != errSecItemNotFound) {
+    NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
+    @throw error;
+  } else if (osStatus != errSecItemNotFound) {
+    result = (__bridge NSArray*)(resultRef);
+    if (result != NULL) {
+      for (id entry in result) {
+        NSString *server = [entry objectForKey:(__bridge NSString *)kSecAttrServer];
+        [servers addObject:server];
+      }
+    }
+  }
+  
+  return servers;
+}
+
 #pragma mark - RNKeychain
 
 #if TARGET_OS_IOS
@@ -589,6 +617,16 @@ RCT_EXPORT_METHOD(getAllGenericPasswordServices:(RCTPromiseResolveBlock)resolve 
                               nil];
     NSArray *services = [self getAllServicesForSecurityClasses:secItemClasses];
     return resolve(services);
+  } @catch (NSError *nsError) {
+    return rejectWithError(reject, nsError);
+  }
+}
+
+RCT_EXPORT_METHOD(getAllInternetPasswordServers:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    NSArray *servers = [self getAllServersForInternetPasswords];
+    return resolve(servers);
   } @catch (NSError *nsError) {
     return rejectWithError(reject, nsError);
   }

--- a/index.js
+++ b/index.js
@@ -348,6 +348,21 @@ export function canImplyAuthentication(options?: Options): Promise<boolean> {
   return RNKeychainManager.canCheckAuthentication(options);
 }
 
+/**
+ * Gets all `kSecAttrServer` values used with internet credentials for iOS.
+ * @return {Promise} Resolves to an array of strings
+ */
+ export async function getAllInternetPasswordServers(): Promise<string[]> {
+  if (Platform.OS !== 'ios') {
+    return Promise.reject(
+      new Error(
+        `getAllInternetPasswordServers() is not supported on ${Platform.OS}`
+      )
+    );
+  }
+  return RNKeychainManager.getAllInternetPasswordServers();
+}
+
 //* ANDROID ONLY */
 
 /**


### PR DESCRIPTION
Similar to how `getAllGenericPasswordServices` returns a list of services, `getAllInternetPasswordServers` returns the list of `kSecAttrServer` values used with internet credentials on iOS.