### PR TITLE
Speed optimisations for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,21 +268,16 @@ If set, `securityLevel` parameter specifies minimum security level that the encr
 
 #### `Keychain.SECURITY_RULES` enum (Android only)
 
-| Key                 | Description                                                                                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NONE`              | No rules. Be dummy, developer control everything                                                                                                            |
-| `AUTOMATIC_UPGRADE` | Upgrade secret to the best available storage as soon as it is available and user request secret extraction. Upgrade not applied till we request the secret. |
+| Key                 | Description                                                                                                                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NONE`              | No rules. Be dummy, developer control everything                                                                                                                                                                           |
+| `AUTOMATIC_UPGRADE` | Upgrade secret to the best available storage as soon as it is available and user request secret extraction. Upgrade not applied till we request the secret. This rule only applies to secrets stored with FacebookConseal. |
 
 ## Important Behavior
 
-### Rule 1: Automatic Security Level Upgrade
+### Rule 1: Automatic Security Level
 
-As a rule library try to apply the best possible encryption and access method for storing secrets.
-
-What does it mean in practical use case?
-
-> Scenario #1: User has a new phone and run on it an application with this module and store secret on device.
-> Several days later user configures biometrics on the device and run application again. When the user will try to access the secret, the library will detect security enhancement and will upgrade secret storage to the best possible.
+As a rule the library will try to apply the best possible encryption for storing secrets. Once the secret is stored however its does not try to upgrade it unless FacebookConseal was used and the option 'SECURITY_RULES' is set to 'AUTOMATIC_UPGRADE'
 
 ---
 
@@ -299,9 +294,9 @@ Developer should implement own logic to allow downgrade and deal with "security 
 
 ---
 
-Q: How to disable automatic upgrade?
+Q: How to enable automatic upgrade for FacebookConseal?
 
-A: Do call `getGenericPassword({ ...otherProps, rules: "none" })` with extra property `rules` set to `none` string value.
+A: Do call `getGenericPassword({ ...otherProps, rules: "AUTOMATIC_UPGRADE" })` with extra property `rules` set to `AUTOMATIC_UPGRADE` string value.
 
 ---
 

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -299,8 +299,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
         final String accessControl = getAccessControlOrDefault(options);
         final boolean useBiometry = getUseBiometry(accessControl);
         cipher = getCipherStorageForCurrentAPILevel(useBiometry);
-
-      }else{
+      } else {
         cipher = getCipherStorageByName(storageName);
       }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
@@ -159,7 +159,6 @@ public class CipherStorageFacebookConceal extends CipherStorageBase {
     throw new CryptoFailedException("Not designed for a call");
   }
 
-
   @NonNull
   @Override
   protected KeyInfo getKeyInfo(@NonNull final Key key) throws GeneralSecurityException {

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
@@ -154,6 +154,14 @@ public class CipherStorageFacebookConceal extends CipherStorageBase {
 
   @NonNull
   @Override
+  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias, @NonNull final boolean isForTesting)
+    throws GeneralSecurityException {
+    throw new CryptoFailedException("Not designed for a call");
+  }
+
+
+  @NonNull
+  @Override
   protected KeyInfo getKeyInfo(@NonNull final Key key) throws GeneralSecurityException {
     throw new CryptoFailedException("Not designed for a call");
   }

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
@@ -180,7 +180,6 @@ public class CipherStorageKeystoreAesCbc extends CipherStorageBase {
     return getKeyGenSpecBuilder(alias, false);
   }
 
-
   /** Get encryption algorithm specification builder instance. */
   @NonNull
   @Override

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbc.java
@@ -173,10 +173,18 @@ public class CipherStorageKeystoreAesCbc extends CipherStorageBase {
 
   //region Implementation
 
+  /** Get builder for encryption and decryption operations with required user Authentication. */
+  @NonNull
+  @Override
+  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias) throws GeneralSecurityException {
+    return getKeyGenSpecBuilder(alias, false);
+  }
+
+
   /** Get encryption algorithm specification builder instance. */
   @NonNull
   @Override
-  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias)
+  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias, @NonNull final boolean isForTesting)
     throws GeneralSecurityException {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       throw new KeyStoreAccessException("Unsupported API" + Build.VERSION.SDK_INT + " version detected.");

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -51,6 +51,8 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
     ALGORITHM_RSA + "/" + BLOCK_MODE_ECB + "/" + PADDING_PKCS1;
   /** Selected encryption key size. */
   public static final int ENCRYPTION_KEY_SIZE = 3072;
+  public static final int ENCRYPTION_KEY_SIZE_WHEN_TESTING = 512;
+
   //endregion
 
   //region Overrides
@@ -209,11 +211,21 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
       this);
   }
 
+
   /** Get builder for encryption and decryption operations with required user Authentication. */
   @NonNull
   @Override
   @SuppressLint("NewApi")
-  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias)
+  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias) throws GeneralSecurityException{
+    return getKeyGenSpecBuilder(alias, false);
+  }
+
+
+  /** Get builder for encryption and decryption operations with required user Authentication. */
+  @NonNull
+  @Override
+  @SuppressLint("NewApi")
+  protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias, @NonNull final boolean isForTesting)
     throws GeneralSecurityException {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       throw new KeyStoreAccessException("Unsupported API" + Build.VERSION.SDK_INT + " version detected.");
@@ -221,13 +233,18 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
 
     final int purposes = KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT;
 
+    int keySize = ENCRYPTION_KEY_SIZE;
+    if (isForTesting){
+      keySize =  ENCRYPTION_KEY_SIZE_WHEN_TESTING;
+    }
+
     return new KeyGenParameterSpec.Builder(alias, purposes)
       .setBlockModes(BLOCK_MODE_ECB)
       .setEncryptionPaddings(PADDING_PKCS1)
       .setRandomizedEncryptionRequired(true)
       .setUserAuthenticationRequired(true)
       .setUserAuthenticationValidityDurationSeconds(5)
-      .setKeySize(ENCRYPTION_KEY_SIZE);
+      .setKeySize(keySize);
   }
 
   /** Get information about provided key. */

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -211,7 +211,6 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
       this);
   }
 
-
   /** Get builder for encryption and decryption operations with required user Authentication. */
   @NonNull
   @Override
@@ -219,7 +218,6 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
   protected KeyGenParameterSpec.Builder getKeyGenSpecBuilder(@NonNull final String alias) throws GeneralSecurityException{
     return getKeyGenSpecBuilder(alias, false);
   }
-
 
   /** Get builder for encryption and decryption operations with required user Authentication. */
   @NonNull
@@ -233,10 +231,7 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
 
     final int purposes = KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT;
 
-    int keySize = ENCRYPTION_KEY_SIZE;
-    if (isForTesting){
-      keySize =  ENCRYPTION_KEY_SIZE_WHEN_TESTING;
-    }
+    final int keySize = isForTesting ? ENCRYPTION_KEY_SIZE_WHEN_TESTING : ENCRYPTION_KEY_SIZE;
 
     return new KeyGenParameterSpec.Builder(alias, purposes)
       .setBlockModes(BLOCK_MODE_ECB)

--- a/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
+++ b/android/src/test/java/com/oblador/keychain/KeychainModuleTests.java
@@ -430,8 +430,6 @@ public class KeychainModuleTests {
     // expected AesCbc usage
     assertThat(provider.mocks.get("KeyGenerator"), notNullValue());
     assertThat(provider.mocks.get("KeyGenerator").get("AES"), notNullValue());
-    assertThat(provider.mocks.get("KeyPairGenerator"), notNullValue());
-    assertThat(provider.mocks.get("KeyPairGenerator").get("RSA"), notNullValue());
     verify(mockPromise).resolve(SecurityLevel.SECURE_SOFTWARE.name());
   }
 


### PR DESCRIPTION
This is a set of changes to Android native component to optimise speed. 

The main reason for slowness is that RSA is a very cpu intensive algorithm. The changes in this PR try to mitigate this by removing unneeded calls and I've also added a less secure (and thereby much faster) encryption option, to be used for testing if the cipher works on the device. 

General policy changes is that the option to upgrade ciphers now defaults to false. And upgrades will only happen for keys stored with FacebookConseal cipher.

**KeychainModule.java - _getGenericPassword_**
We no longer always check for available ciphers on the device when getting a password. We instead only do this test if we should upgrade ciphers. 

**CipherStorageKeystoreRsaEcb.java**
Adding an alternative key size to use for testing the cipher. Real encryption uses 3072 bits, but for testing purpose we now only use 512 bits. Which is a lot faster to calculate. 


**CipherStorageBase.java  - _getCapabilityLevel_**
When evaluating which ciphers exists and at what capability level. The check to see if secure hardware is available was removed as this is a very expensive operation and it's not needed for evaluation purpose in that step.

**CipherStorageBase.java - _getCipherStorageForCurrentAPILevel_**
Small optimisation of order of evaluation


