### PR TITLE
Application password support by iOS

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -136,6 +136,14 @@ NSString *authenticationPromptValue(NSDictionary *options)
   return nil;
 }
 
+NSString *applicationPasswordValue(NSDictionary *options)
+{
+  if (options && options[@"applicationPassword"] != nil) {
+    return options[@"applicationPassword"];
+  }
+  return nil;
+}
+
 #pragma mark - Proposed functionality - Helpers
 
 #define kAuthenticationType @"authenticationType"
@@ -350,12 +358,21 @@ RCT_EXPORT_METHOD(setGenericPasswordForOptions:(NSDictionary *)options
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSString *service = serviceValue(options);
-  NSDictionary *attributes = attributes = @{
-    (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
-    (__bridge NSString *)kSecAttrService: service,
-    (__bridge NSString *)kSecAttrAccount: username,
-    (__bridge NSString *)kSecValueData: [password dataUsingEncoding:NSUTF8StringEncoding]
-  };
+  NSString *applicationPassword = applicationPasswordValue(options);
+    
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithDictionary: @{
+        (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
+        (__bridge NSString *)kSecAttrService: service,
+        (__bridge NSString *)kSecAttrAccount: username,
+        (__bridge NSString *)kSecValueData: [password dataUsingEncoding:NSUTF8StringEncoding]
+      }];
+    
+    if (applicationPassword != nil) {
+        LAContext *context =  [LAContext new];
+        [context setCredential: [applicationPassword dataUsingEncoding: NSUTF8StringEncoding] type: LACredentialTypeApplicationPassword];
+        
+        attributes[(__bridge NSString *)kSecUseAuthenticationContext] = context;
+    }
 
   [self deletePasswordsForService:service];
 
@@ -368,15 +385,23 @@ RCT_EXPORT_METHOD(getGenericPasswordForOptions:(NSDictionary * __nullable)option
 {
   NSString *service = serviceValue(options);
   NSString *authenticationPrompt = authenticationPromptValue(options);
+  NSString *applicationPassword = applicationPasswordValue(options);
 
-  NSDictionary *query = @{
-    (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
-    (__bridge NSString *)kSecAttrService: service,
-    (__bridge NSString *)kSecReturnAttributes: (__bridge id)kCFBooleanTrue,
-    (__bridge NSString *)kSecReturnData: (__bridge id)kCFBooleanTrue,
-    (__bridge NSString *)kSecMatchLimit: (__bridge NSString *)kSecMatchLimitOne,
-    (__bridge NSString *)kSecUseOperationPrompt: authenticationPrompt
-  };
+  NSMutableDictionary *query = [NSMutableDictionary dictionaryWithDictionary: @{
+      (__bridge NSString *)kSecClass: (__bridge id)(kSecClassGenericPassword),
+      (__bridge NSString *)kSecAttrService: service,
+      (__bridge NSString *)kSecReturnAttributes: (__bridge id)kCFBooleanTrue,
+      (__bridge NSString *)kSecReturnData: (__bridge id)kCFBooleanTrue,
+      (__bridge NSString *)kSecMatchLimit: (__bridge NSString *)kSecMatchLimitOne,
+      (__bridge NSString *)kSecUseOperationPrompt: authenticationPrompt
+    }];
+    
+    if (applicationPassword != nil) {
+        LAContext *context =  [LAContext new];
+        [context setCredential: [applicationPassword dataUsingEncoding: NSUTF8StringEncoding] type: LACredentialTypeApplicationPassword];
+        
+        query[(__bridge NSString *)kSecUseAuthenticationContext] = context;
+    }
 
   // Look up service in the keychain
   NSDictionary *found = nil;

--- a/typings/react-native-keychain.d.ts
+++ b/typings/react-native-keychain.d.ts
@@ -81,6 +81,7 @@ declare module 'react-native-keychain' {
     securityLevel?: SECURITY_LEVEL;
     storage?: STORAGE_TYPE;
     rules?: SECURITY_RULES;
+    applicationPassword?: string | undefined;
   }
 
   function setGenericPassword(


### PR DESCRIPTION
Hi, 

This minor update handles case when user wants to use Application password  (not device password) to secure secret in keychain. With the update version uses optional application password if provided and falls back to user settings biometrics in case if application password not provided.

This way user can use their own UI to collect password for keychain which is different from device password.