### PR TITLE
Fix android native tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,24 +65,24 @@ dependencies {
   implementation "com.facebook.conceal:conceal:1.1.3@aar"
 
   /* Unit Testing Frameworks */
-  testImplementation 'junit:junit:4.13'
+  testImplementation 'junit:junit:4.13.2'
 
   /* Mockito, https://mvnrepository.com/artifact/org.mockito/mockito-inline */
-  testImplementation 'org.mockito:mockito-inline:3.2.4'
+  testImplementation 'org.mockito:mockito-inline:4.0.0'
 
   /* https://mvnrepository.com/artifact/org.hamcrest/hamcrest/2.1 */
   testImplementation 'org.hamcrest:hamcrest:2.2'
 
   /* http://robolectric.org/getting-started/ */
-  testImplementation("org.robolectric:robolectric:4.3.1")
+  testImplementation("org.robolectric:robolectric:4.7.3")
 
   /* https://mvnrepository.com/artifact/androidx.test.ext/junit */
-  testImplementation "androidx.test.ext:junit:1.1.2-alpha03"
+  testImplementation "androidx.test.ext:junit:1.1.4-alpha05"
 
   /* https://mvnrepository.com/artifact/androidx.test/core */
-  testImplementation 'androidx.test:core:1.3.0-alpha03'
-  testImplementation "androidx.test:runner:1.3.0-alpha03"
-  testImplementation "androidx.test:monitor:1.3.0-alpha03"
+  testImplementation 'androidx.test:core:1.4.1-alpha05'
+  testImplementation "androidx.test:runner:1.5.0-alpha02"
+  testImplementation "androidx.test:monitor:1.6.0-alpha02"
 
   // Uncomment for including JRE implementation of crypto api (that is used in Robolectric tests)
   // testImplementation fileTree(dir: "${System.properties.get("java.home")}/lib", include: ["jce.jar"])

--- a/android/src/test/java/com/oblador/keychain/MocksForProvider.java
+++ b/android/src/test/java/com/oblador/keychain/MocksForProvider.java
@@ -22,7 +22,7 @@ import javax.crypto.SecretKey;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings({"WeakerAccess"})
@@ -59,35 +59,38 @@ public final class MocksForProvider {
 
   private void innerConfiguration(@NonNull final String type, @NonNull final Provider provider, @Nullable final Map<String, Object> configuration)
     throws InvalidKeySpecException, NoSuchAlgorithmException, UnrecoverableKeyException {
-    when(service.getProvider()).thenReturn(provider);
-    when(kpgSpi.generateKeyPair()).thenReturn(keyPair);
-    when(keyPair.getPrivate()).thenReturn(privateKey);
 
-    when(keyInfo.isInsideSecureHardware()).thenReturn(returnForIsInsideSecureHardware(configuration));
+    // JDK 11 introduced null checks inside the getInstance methods
+    doReturn("").when(secretKey).getAlgorithm();
+    doReturn("").when(privateKey).getAlgorithm();
 
-    when(kgSpi.engineGenerateKey()).thenReturn(secretKey);
-    when(skfSpi.engineGetKeySpec(any(), any())).thenReturn(keyInfo);
-    when(kfSpi.engineGetKeySpec(any(), any())).thenReturn(keyInfo);
-    when(ksSpi.engineGetKey(any(), any())).thenReturn(key);
+    doReturn(provider).when(service).getProvider();
+    doReturn(keyPair).when(kpgSpi).generateKeyPair();
+    doReturn(privateKey).when(keyPair).getPrivate();
+    doReturn(returnForIsInsideSecureHardware(configuration)).when(keyInfo).isInsideSecureHardware();
+    doReturn(secretKey).when(kgSpi).engineGenerateKey();
+    doReturn(keyInfo).when(skfSpi).engineGetKeySpec(any(), any());
+    doReturn(keyInfo).when(kfSpi).engineGetKeySpec(any(), any());
+    doReturn(key).when(ksSpi).engineGetKey(any(), any());
 
     switch (type) {
       case KEY_GENERATOR:
-        when(service.newInstance(any())).thenReturn(kgSpi);
+        doReturn(kgSpi).when(service).newInstance(any());
         break;
       case KEY_PAIR_GENERATOR:
-        when(service.newInstance(any())).thenReturn(kpgSpi);
+        doReturn(kpgSpi).when(service).newInstance(any());
         break;
       case KEY_FACTORY:
-        when(service.newInstance(isNull())).thenReturn(kfSpi);
+        doReturn(kfSpi).when(service).newInstance(isNull());
         break;
       case KEY_STORE:
-        when(service.newInstance(isNull())).thenReturn(ksSpi);
+        doReturn(ksSpi).when(service).newInstance(isNull());
         break;
       case SECRET_KEY_FACTORY:
-        when(service.newInstance(isNull())).thenReturn(skfSpi);
+        doReturn(skfSpi).when(service).newInstance(isNull());
         break;
       case KEY_CIPHER:
-        when(service.newInstance(isNull())).thenReturn(cSpi);
+        doReturn(cSpi).when(service).newInstance(isNull());
         break;
       default:
         System.err.println("requested unsupported type: " + type);

--- a/android/src/test/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbcTests.java
+++ b/android/src/test/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesCbcTests.java
@@ -29,6 +29,7 @@ import javax.crypto.SecretKey;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
 
 @RunWith(RobolectricTestRunner.class)
 public class CipherStorageKeystoreAesCbcTests {
@@ -65,6 +66,8 @@ public class CipherStorageKeystoreAesCbcTests {
   public void testGetSecurityLevel_api23() throws Exception {
     final CipherStorageKeystoreRsaEcb instance = new CipherStorageKeystoreRsaEcb();
     final Key mock = Mockito.mock(SecretKey.class);
+
+    doReturn("").when(mock).getAlgorithm(); // JDK 11 introduced null checks inside the getInstance methods
 
     final SecurityLevel level = instance.getSecurityLevel(mock);
 

--- a/android/src/test/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcbTests.java
+++ b/android/src/test/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcbTests.java
@@ -34,6 +34,7 @@ import javax.crypto.SecretKey;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
@@ -71,6 +72,8 @@ public class CipherStorageKeystoreRsaEcbTests {
   public void testGetSecurityLevel_api23() throws Exception {
     final CipherStorageKeystoreAesCbc instance = new CipherStorageKeystoreAesCbc();
     final Key mock = Mockito.mock(SecretKey.class);
+
+    doReturn("").when(mock).getAlgorithm(); // JDK 11 introduced null checks inside the getInstance methods
 
     final SecurityLevel level = instance.getSecurityLevel(mock);
 


### PR DESCRIPTION
### Overview
Starting from JDK 11 there are more nullability checks inside the GetInstance methods of javax.crypto package.
![Screenshot 2022-04-11 at 15 54 59](https://user-images.githubusercontent.com/1249919/163209769-a537c99b-85f9-4076-bcf2-9097a6d8bfb5.png)

This causes the native tests to fail. This is being fixed by mocking the result of `getAlgorithm` method on the keys.

### Other changes:
- Bump all test dependencies to the latest
- Replace `when/doReturn` with `doReturn/when` to fix debugging tests in AS

