### PR TITLE
macos: Use iOS-style keychain

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -204,6 +204,10 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
 
   NSMutableDictionary *mAttributes = attributes.mutableCopy;
 
+  if (@available(macOS 10.15, *)) {
+    mAttributes[(__bridge NSString *)kSecUseDataProtectionKeychain] = @(YES);
+  }
+
   if (accessControl) {
     NSError *aerr = nil;
 #if TARGET_OS_IOS


### PR DESCRIPTION
Hey.
This PR makes sure that iOS-style keychain is used for the macOS target. The reason for this is it allows portability between iOS and macOS apps.
This is considered to be good practice according to Apple, there's some more info about it here: https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain