### PR TITLE
Remove a thread blocking behaviour

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
@@ -10,6 +10,7 @@ import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
 import java.security.Key;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public interface CipherStorage {
@@ -92,19 +93,21 @@ public interface CipherStorage {
    * That can happens during migration from one version of library to another.
    */
   @NonNull
-  DecryptionResult decrypt(@NonNull final String alias,
-                           @NonNull final byte[] username,
-                           @NonNull final byte[] password,
-                           @NonNull final SecurityLevel level)
-    throws CryptoFailedException;
+  CompletableFuture<DecryptionResult> decrypt(@NonNull final String alias,
+                                              @NonNull final byte[] username,
+                                              @NonNull final byte[] password,
+                                              @NonNull final SecurityLevel level)
+            throws CryptoFailedException;
 
-  /** Decrypt the credentials but redirect results of operation to handler. */
-  void decrypt(@NonNull final DecryptionResultHandler handler,
-               @NonNull final String alias,
-               @NonNull final byte[] username,
-               @NonNull final byte[] password,
-               @NonNull final SecurityLevel level)
-    throws CryptoFailedException;
+  /**
+   * Decrypt the credentials but redirect results of operation to handler.
+   */
+  CompletableFuture<DecryptionResult> decrypt(@NonNull final DecryptionResultHandler handler,
+                                              @NonNull final String alias,
+                                              @NonNull final byte[] username,
+                                              @NonNull final byte[] password,
+                                              @NonNull final SecurityLevel level)
+            throws CryptoFailedException;
 
   /** Remove key (by alias) from storage. */
   void removeKey(@NonNull final String alias) throws KeyStoreAccessException;

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/AuthSerialQueue.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/AuthSerialQueue.java
@@ -1,0 +1,71 @@
+package com.oblador.keychain.decryptionHandler;
+
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+interface AuthCb {
+    void run(final CompletableFuture<CipherStorage.DecryptionResult> cb);
+}
+
+public class AuthSerialQueue {
+    private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
+    /**
+     * Lock is needed to not call a job is there is already one in progress
+     */
+    private final AtomicBoolean lock = new AtomicBoolean(false);
+
+    /**
+     * So we want to run auth related things in serial order
+     * but at the same time we don't want to lock a thread.
+     * For that reason we utilize a queue that stores `Runnable`s
+     * for every `Runnable` we create a `CompletableFuture`,
+     * that must be `completed` by that callback.
+     * Only after that the next `Runnable` will be started.
+     */
+    public CompletableFuture<CipherStorage.DecryptionResult> add(AuthCb cb) {
+        final CompletableFuture<CipherStorage.DecryptionResult> intention = new CompletableFuture<>();
+        CompletableFuture<CipherStorage.DecryptionResult> queueLoop = intention.handle(((decryptionResult, throwable) -> {
+            lock.set(false);
+            this.flush();
+            if (throwable != null) {
+                if(throwable instanceof CompletionException)
+                    throwable = throwable.getCause();
+                throw new CompletionException(throwable);
+            }
+            return decryptionResult;
+        }));
+
+        queue.add(() -> {
+            try {
+                cb.run(intention);
+            } catch (Throwable err) {
+                intention.completeExceptionally(err);
+            }
+        });
+
+        flush();
+
+        return queueLoop;
+    }
+
+    private void flush() {
+        if (lock.get()) {
+            return;
+        }
+
+        final Runnable job = queue.poll();
+
+        // All work is done for now
+        if (job == null) {
+            return;
+        }
+
+        lock.set(true);
+        job.run();
+    }
+}

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
@@ -6,24 +6,11 @@ import androidx.annotation.Nullable;
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
 /** Handler that allows to inject some actions during decrypt operations. */
 public interface DecryptionResultHandler {
   /** Ask user for interaction, often its unlock of keystore by biometric data providing. */
-  void askAccessPermissions(@NonNull final DecryptionContext context);
-
-  /**
-   *
-   */
-  void onDecrypt(@Nullable final DecryptionResult decryptionResult, @Nullable final Throwable error);
-
-  /** Get reference on results. */
-  @Nullable
-  DecryptionResult getResult();
-
-  /** Get reference on capture error. */
-  @Nullable
-  Throwable getError();
-
-  /** Block thread and wait for any result of execution. */
-  void waitResult();
+  CompletableFuture<DecryptionResult> authenticate(@NonNull final DecryptionResultJob job);
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
@@ -7,39 +7,19 @@ import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.concurrent.CompletableFuture;
+
 public class DecryptionResultHandlerNonInteractive implements DecryptionResultHandler {
-  private DecryptionResult result;
-  private Throwable error;
-
   @Override
-  public void askAccessPermissions(@NonNull final DecryptionContext context) {
-    final CryptoFailedException failure = new CryptoFailedException(
-      "Non interactive decryption mode.");
-
-    onDecrypt(null, failure);
-  }
-
-  @Override
-  public void onDecrypt(@Nullable final DecryptionResult decryptionResult,
-                        @Nullable final Throwable error) {
-    this.result = decryptionResult;
-    this.error = error;
-  }
-
-  @Nullable
-  @Override
-  public DecryptionResult getResult() {
+  public CompletableFuture<DecryptionResult> authenticate(@NonNull DecryptionResultJob job) {
+    final CompletableFuture<DecryptionResult> result = new CompletableFuture<>();
+    try {
+      result.complete(job.get());
+    } catch (final Throwable fail) {
+      result.completeExceptionally(fail);
+    }
     return result;
-  }
-
-  @Nullable
-  @Override
-  public Throwable getError() {
-    return error;
-  }
-
-  @Override
-  public void waitResult() {
-    /* do nothing, expected synchronized call in one thread */
   }
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultJob.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultJob.java
@@ -1,0 +1,12 @@
+package com.oblador.keychain.decryptionHandler;
+
+import android.security.keystore.UserNotAuthenticatedException;
+
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public interface DecryptionResultJob {
+    CipherStorage.DecryptionResult get() throws UserNotAuthenticatedException, IOException, GeneralSecurityException;
+}


### PR DESCRIPTION
Hi guys.
Thanks for your awesome library, we've been using it for a long time, so I want to contribute in return.

Recently we encountered a lot of crashes. Though it's not actual crashes as I found out, this is when a system close the app, because it didn't response for a while (a thread didn't get unlocked). There is an example of such a "crash":
```
io.sentry.android.core.ApplicationNotResponding: Application Not Responding for at least 5000 ms.
    at sun.misc.Unsafe.park(Unsafe.java)
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:190)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:868)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1023)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1334)
    at java.util.concurrent.Semaphore.acquire(Semaphore.java:318)
    at com.swmansion.reanimated.NodesManager.performOperations(NodesManager.java:251)
    at com.swmansion.reanimated.NodesManager.onAnimationFrame(NodesManager.java:280)
    at com.swmansion.reanimated.NodesManager.access$000(NodesManager.java:65)
    at com.swmansion.reanimated.NodesManager$1.doFrameGuarded(NodesManager.java:170)
    at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:29)
    at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:175)
    at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:85)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1140)
    at android.view.Choreographer.doCallbacks(Choreographer.java:946)
    at android.view.Choreographer.doFrame(Choreographer.java:870)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1127)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:210)
    at android.os.Looper.loop(Looper.java:299)
    at android.app.ActivityThread.main(ActivityThread.java:8105)
    at java.lang.reflect.Method.invoke(Method.java)
```
IMO it looks like a deadlock. I tried to trace it without any luck, I tried to stop any other activity (animations) while keychain is operating, also didn't help. So I decided to untie the deadlock in a place that I'm sure is involved in it - [thread block](https://github.com/oblador/react-native-keychain/blob/master/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java#L142-L144).
Correct me if I wrong, but as far as I understand the necessity of it, is that API just wasn't designed to be asynchronous, and to prevent concurrent calls to biometry API thread block was introduced. So I tried to untackle this and make it concurrent, at the same time keeping serial access to biometry calls.

It isn't final solution, though we already shipped it to our beta users, and they confirmed that the crash is gone. I would like to fix all tests, though as it isn't fast, I would like to receive your feedback on that, as it seems like a very big change, and I would like to reach a consensus on internal APIs first. Looking forward for it!