### PR TITLE
Fix autolinking in React Native 0.69

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,9 +1,6 @@
-const path = require('path');
-
 module.exports = {
   dependency: {
     platforms: {
-      ios: { podspecPath: path.join(__dirname, 'RNKeychain.podspec') },
       android: {
         packageImportPath: 'import com.oblador.keychain.KeychainPackage;',
         packageInstance: 'new KeychainPackage()',


### PR DESCRIPTION
CLI version 8 introduced large changes to autolinking https://github.com/react-native-community/cli/pull/1537 which breaks this library, due to a redundant podspec configuration. It's not needed, so removing it fixes it while retaining backwards support. 