### PR TITLE
ios 13 check

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -203,12 +203,8 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
 
   NSMutableDictionary *mAttributes = attributes.mutableCopy;
 
-  if (@available(macOS 10.15, *)) {
-      if (@available(iOS 13.0, *)) {
-          mAttributes[(__bridge NSString *)kSecUseDataProtectionKeychain] = @(YES);
-      } else {
-          // Fallback on earlier versions
-      }
+  if (@available(macOS 10.15, iOS 13.0, *)) {
+      mAttributes[(__bridge NSString *)kSecUseDataProtectionKeychain] = @(YES);
   }
 
   if (accessControl) {

--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -204,7 +204,11 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
   NSMutableDictionary *mAttributes = attributes.mutableCopy;
 
   if (@available(macOS 10.15, *)) {
-    mAttributes[(__bridge NSString *)kSecUseDataProtectionKeychain] = @(YES);
+      if (@available(iOS 13.0, *)) {
+          mAttributes[(__bridge NSString *)kSecUseDataProtectionKeychain] = @(YES);
+      } else {
+          // Fallback on earlier versions
+      }
   }
 
   if (accessControl) {


### PR DESCRIPTION
'kSecUseDataProtectionKeychain' is only available on iOS 13.0 or newer

Enclose 'kSecUseDataProtectionKeychain' in an @available check to silence this warning

Probable Cause https://github.com/oblador/react-native-keychain/pull/536