### PR TITLE
[Fix][Android] Avoid blocking threads to prevent deadlocks

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
@@ -1,10 +1,10 @@
 package com.oblador.keychain.cipherStorage;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.oblador.keychain.SecurityLevel;
 import com.oblador.keychain.decryptionHandler.DecryptionResultHandler;
+import com.oblador.keychain.decryptionHandler.DecryptionResultListener;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 import com.oblador.keychain.exceptions.KeyStoreAccessException;
 
@@ -91,20 +91,13 @@ public interface CipherStorage {
    * In case of key stored in weaker security level than required will be raised exception.
    * That can happens during migration from one version of library to another.
    */
-  @NonNull
-  DecryptionResult decrypt(@NonNull final String alias,
-                           @NonNull final byte[] username,
-                           @NonNull final byte[] password,
-                           @NonNull final SecurityLevel level)
-    throws CryptoFailedException;
-
-  /** Decrypt the credentials but redirect results of operation to handler. */
   void decrypt(@NonNull final DecryptionResultHandler handler,
                @NonNull final String alias,
                @NonNull final byte[] username,
                @NonNull final byte[] password,
-               @NonNull final SecurityLevel level)
-    throws CryptoFailedException;
+               @NonNull final SecurityLevel level,
+               @NonNull final DecryptionResultListener listener)
+          throws CryptoFailedException;
 
   /** Remove key (by alias) from storage. */
   void removeKey(@NonNull final String alias) throws KeyStoreAccessException;

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandler.java
@@ -1,29 +1,13 @@
 package com.oblador.keychain.decryptionHandler;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
-import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
 
 /** Handler that allows to inject some actions during decrypt operations. */
 public interface DecryptionResultHandler {
   /** Ask user for interaction, often its unlock of keystore by biometric data providing. */
-  void askAccessPermissions(@NonNull final DecryptionContext context);
+  void askAccessPermissions(@NonNull final DecryptionContext context,
+                            @NonNull final DecryptionResultListener listener);
 
-  /**
-   *
-   */
-  void onDecrypt(@Nullable final DecryptionResult decryptionResult, @Nullable final Throwable error);
-
-  /** Get reference on results. */
-  @Nullable
-  DecryptionResult getResult();
-
-  /** Get reference on capture error. */
-  @Nullable
-  Throwable getError();
-
-  /** Block thread and wait for any result of execution. */
-  void waitResult();
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
@@ -57,7 +57,7 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
   /** Called when an unrecoverable error has been encountered and the operation is complete. */
   @Override
   public void onAuthenticationError(final int errorCode, @NonNull final CharSequence errString) {
-    handler.post(
+    handler.postAtFrontOfQueue(
         () -> {
           final CryptoFailedException error =
               new CryptoFailedException("code: " + errorCode + ", msg: " + errString);
@@ -69,7 +69,7 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
   @Override
   public void onAuthenticationSucceeded(
       @NonNull final BiometricPrompt.AuthenticationResult result) {
-    handler.post(
+    handler.postAtFrontOfQueue(
         () -> {
           try {
             if (null == context)

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometricManualRetry.java
@@ -76,7 +76,6 @@ public class DecryptionResultHandlerInteractiveBiometricManualRetry extends Decr
     // code can be executed only from MAIN thread
     if (Thread.currentThread() != Looper.getMainLooper().getThread()) {
       activity.runOnUiThread(this::startAuthentication);
-      waitResult();
       return;
     }
 

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerNonInteractive.java
@@ -1,45 +1,18 @@
 package com.oblador.keychain.decryptionHandler;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionContext;
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult;
 import com.oblador.keychain.exceptions.CryptoFailedException;
 
 public class DecryptionResultHandlerNonInteractive implements DecryptionResultHandler {
-  private DecryptionResult result;
-  private Throwable error;
-
   @Override
-  public void askAccessPermissions(@NonNull final DecryptionContext context) {
+  public void askAccessPermissions(@NonNull final DecryptionContext context,
+                                   @NonNull final DecryptionResultListener listener) {
     final CryptoFailedException failure = new CryptoFailedException(
       "Non interactive decryption mode.");
 
-    onDecrypt(null, failure);
-  }
-
-  @Override
-  public void onDecrypt(@Nullable final DecryptionResult decryptionResult,
-                        @Nullable final Throwable error) {
-    this.result = decryptionResult;
-    this.error = error;
-  }
-
-  @Nullable
-  @Override
-  public DecryptionResult getResult() {
-    return result;
-  }
-
-  @Nullable
-  @Override
-  public Throwable getError() {
-    return error;
-  }
-
-  @Override
-  public void waitResult() {
-    /* do nothing, expected synchronized call in one thread */
+    listener.onError(failure);
   }
 }

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultListener.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultListener.java
@@ -1,0 +1,12 @@
+package com.oblador.keychain.decryptionHandler;
+
+import androidx.annotation.NonNull;
+
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+public interface DecryptionResultListener {
+  /** Triggered when decryption has finished successfully */
+  void onDecrypt(@NonNull final CipherStorage.DecryptionResult decryptionResult);
+  /** Triggered when error occured during decryption */
+  void onError(@NonNull final Throwable error);
+}

--- a/android/src/test/java/com/oblador/keychain/decryptionHandler/MockDecryptionHandlerListener.java
+++ b/android/src/test/java/com/oblador/keychain/decryptionHandler/MockDecryptionHandlerListener.java
@@ -1,0 +1,28 @@
+package com.oblador.keychain.decryptionHandler;
+
+import androidx.annotation.NonNull;
+
+import com.oblador.keychain.cipherStorage.CipherStorage;
+
+public class MockDecryptionHandlerListener implements DecryptionResultListener {
+  private CipherStorage.DecryptionResult result = null;
+  private Throwable error = null;
+
+  @Override
+  public void onDecrypt(@NonNull CipherStorage.DecryptionResult decryptionResult) {
+    this.result = decryptionResult;
+  }
+
+  @Override
+  public void onError(@NonNull Throwable error) {
+    this.error = error;
+  }
+
+  public CipherStorage.DecryptionResult getResult() {
+    return result;
+  }
+
+  public Throwable getError() {
+    return error;
+  }
+}


### PR DESCRIPTION
Similar to https://github.com/oblador/react-native-keychain/pull/547, I've run into issues with main thread deadlocking when using this library to show a BiometricPrompt and have seen an increased rate of ANRs on Crashlytics.
Upon further digging it was due to `react-native-reanimated` attempting to acquire a lock on the main thread, but since this library waits on the JS thread for the BiometricPrompt to show and finish on the main thread, a deadlock occurs.
This library avoids blocking the JS thread by using a listener to resolve a promise when decryption finishes. Since there are no additional dependencies, this should be compatible up to API level 21.

This PR should fix https://github.com/oblador/react-native-keychain/issues/525
