### PR TITLE
[Fix][Android] Unsupported RSA key size for StrongBox

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -50,7 +50,7 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
   public static final String TRANSFORMATION_RSA_ECB_PKCS1 =
     ALGORITHM_RSA + "/" + BLOCK_MODE_ECB + "/" + PADDING_PKCS1;
   /** Selected encryption key size. */
-  public static final int ENCRYPTION_KEY_SIZE = 3072;
+  public static final int ENCRYPTION_KEY_SIZE = 2048;
   public static final int ENCRYPTION_KEY_SIZE_WHEN_TESTING = 512;
 
   //endregion


### PR DESCRIPTION
Upon app startup, I'm noticing this error showing up

```
11-13 19:16:28.052   711   711 E android.hardware.keymaster@4.1-service.citadel: GenerateKey : device response error code: UNSUPPORTED_KEY_SIZE
11-13 19:16:28.052   749   779 E keystore2: keystore2::error: In generate_key.
11-13 19:16:28.052   749   779 E keystore2:
11-13 19:16:28.052   749   779 E keystore2: Caused by:
11-13 19:16:28.052   749   779 E keystore2:     0: While generating Key without explicit attestation key.
11-13 19:16:28.052   749   779 E keystore2:     1: Error::Km(ErrorCode(-6))
11-13 19:16:28.059 27168 27303 W CipherStorageBase: StrongBox security storage is not available.
11-13 19:16:28.059 27168 27303 W CipherStorageBase: java.security.ProviderException: Failed to generate key pair.
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.keystore2.AndroidKeyStoreKeyPairGeneratorSpi.generateKeyPairHelper(AndroidKeyStoreKeyPairGeneratorSpi.java:620)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.keystore2.AndroidKeyStoreKeyPairGeneratorSpi.generateKeyPair(AndroidKeyStoreKeyPairGeneratorSpi.java:545)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:746)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.cipherStorage.CipherStorageKeystoreRsaEcb.generateKey(CipherStorageKeystoreRsaEcb.java:249)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.cipherStorage.CipherStorageBase.tryGenerateStrongBoxSecurityKey(CipherStorageBase.java:475)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.cipherStorage.CipherStorageBase.tryGenerateStrongBoxSecurityKey(CipherStorageBase.java:460)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.cipherStorage.CipherStorageBase.generateKeyAndStoreUnderAlias(CipherStorageBase.java:413)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.KeychainModule.internalWarmingBestCipher(KeychainModule.java:175)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.KeychainModule.$r8$lambda$DYujhqpjRgfFQ_gyuwMwyxxqDlk(Unknown Source:0)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at com.oblador.keychain.KeychainModule$$ExternalSyntheticLambda0.run(Unknown Source:2)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at java.lang.Thread.run(Thread.java:1012)
11-13 19:16:28.059 27168 27303 W CipherStorageBase: Caused by: android.security.KeyStoreException: Unsupported key size
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.KeyStore2.getKeyStoreException(KeyStore2.java:356)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.KeyStoreSecurityLevel.handleExceptions(KeyStoreSecurityLevel.java:57)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.KeyStoreSecurityLevel.generateKey(KeyStoreSecurityLevel.java:145)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     at android.security.keystore2.AndroidKeyStoreKeyPairGeneratorSpi.generateKeyPairHelper(AndroidKeyStoreKeyPairGeneratorSpi.java:587)
11-13 19:16:28.059 27168 27303 W CipherStorageBase:     ... 10 more
```

It seems like RSA 3072 is not supported for StrongBox but 2048 is (reference: https://developer.android.com/training/articles/keystore). Changing it to 2048 makes the error disappear.