### PR TITLE
Disable Android Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,3 @@ org.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options\="-Xmx3g" -Dfile.encoding=
 # AndroidX
 #
 android.useAndroidX=true
-android.enableJetifier=true
-
-##
-## Android Support Library
-##
-#android.useAndroidX=false
-#android.enableJetifier=false


### PR DESCRIPTION
## Overview
As the project is migrated to AndroidX and robolectric is [updated](https://github.com/oblador/react-native-keychain/commit/6963bfd6c1e4e70b23c02f54e319523b62077aef#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL82) to 4.7.3 (which include one more [migration](https://github.com/robolectric/robolectric/pull/5525) to androidx), we should be safe by disabling `jetifier` on Android, which removes additional build steps and potentially saves build time.

The flag is [false](https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project) by default if it is not specified.