### PR TITLE
[Fix][Android] Bugfix for lambda functions not workin in older projects.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,12 @@ android {
     versionName "1.0"
   }
 
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+
   lintOptions {
     abortOnError false
   }


### PR DESCRIPTION
# Issue #571 


The following lines of code were added to android's build.gradle.
```
  compileOptions {
    sourceCompatibility JavaVersion.VERSION_1_8
    targetCompatibility JavaVersion.VERSION_1_8
  }
```

What this fixes:
* Older react native projects not handling lambda functions.

Error Message:
```
 error: method references are not supported in -source 7
    final Thread warmingUp = new Thread(instance::internalWarmingBestCipher, "keychain-warming-up");
                                                  ^
  (use -source 8 or higher to enable method references)
```

