### PR TITLE
[WIP] upgrade: bump `gradle-test-logger-plugin` to `3.2.0`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.adarshr:gradle-test-logger-plugin:2.0.0'
+    classpath 'com.adarshr:gradle-test-logger-plugin:3.2.0'
   }
 }
 


### PR DESCRIPTION
We first discovered this error over here : https://github.com/status-im/status-mobile/pull/17062#issuecomment-1684914555

This PR attempts to upgrade `gradle-test-logger-plugin` classpath to the latest version available.

Also as reported here : https://github.com/oblador/react-native-keychain/issues/595#issuecomment-1568657311 upgrading from 2.0.0 to 2.1.0 worked for them.

fixes : #595 

note : Some initial tests are pending, will mark this PR ready for review when I am confident that this fixes the issue.

Status : WIP