### PR TITLE
use setUserAuthenticationParameters for android >= 11

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -233,13 +233,21 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
 
     final int keySize = isForTesting ? ENCRYPTION_KEY_SIZE_WHEN_TESTING : ENCRYPTION_KEY_SIZE;
 
-    return new KeyGenParameterSpec.Builder(alias, purposes)
+    final int validityDuration = 5;
+    final KeyGenParameterSpec.Builder keyGenParameterSpecBuilder = new KeyGenParameterSpec.Builder(alias, purposes)
       .setBlockModes(BLOCK_MODE_ECB)
       .setEncryptionPaddings(PADDING_PKCS1)
       .setRandomizedEncryptionRequired(true)
       .setUserAuthenticationRequired(true)
-      .setUserAuthenticationValidityDurationSeconds(5)
       .setKeySize(keySize);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      keyGenParameterSpecBuilder.setUserAuthenticationParameters(validityDuration, KeyProperties.AUTH_BIOMETRIC_STRONG);
+    } else {
+      keyGenParameterSpecBuilder.setUserAuthenticationValidityDurationSeconds(validityDuration);
+    }
+
+    return keyGenParameterSpecBuilder;
   }
 
   /** Get information about provided key. */


### PR DESCRIPTION
Fix for Android >= 11 to force the use of biometry if required : an attacker could bypass the use of biometry by unlocking the device with the pin and then could access the keychain, even though we would like it to be protected with the biometry.

Fix coming from a comment on this PR : https://github.com/oblador/react-native-keychain/pull/592

It should solve for Android >=11 the issues : 
- https://github.com/oblador/react-native-keychain/issues/593
- https://github.com/oblador/react-native-keychain/issues/518

However, it does not solve the issue for Android < 11 due to the way the keychain is implemented on Android.
