### PR TITLE
fix: unrecognized platform name visionOS

### DIFF
--- a/RNKeychainManager/RNKeychainManager.m
+++ b/RNKeychainManager/RNKeychainManager.m
@@ -333,11 +333,11 @@ RCT_EXPORT_METHOD(getSupportedBiometryType:(RCTPromiseResolveBlock)resolve
   BOOL canBeProtected = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
 
   if (!aerr && canBeProtected) {
-    if (@available(visionOS 1, *)) {
+    #if TARGET_OS_VISION
       if (context.biometryType == LABiometryTypeOpticID) {
         return resolve(kBiometryTypeOpticID);
       }
-    }
+    #endif
     if (@available(iOS 11, *)) {
       if (context.biometryType == LABiometryTypeFaceID) {
         return resolve(kBiometryTypeFaceID);


### PR DESCRIPTION
Fixes #624 

Remove `@available(visionOS 1, *)`, which is only available on Xcode 15 and above. Use obj-c preprocessor directives instead.

This was following the same approach as iOS in the lines below `@available(iOS 11, *)`. iOS needs this because FaceID is only available on iOS 11 and above. VisionOS does not need it because visionOS 1 already has OpticID since launch.

Tested on Xcode 14.3.1 and 15.2.