### PR TITLE
chore(docs): fix test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   />
 </p>
 
-[![Travis](https://img.shields.io/travis/oblador/react-native-keychain.svg)](https://travis-ci.org/oblador/react-native-keychain) [![npm](https://img.shields.io/npm/v/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain) [![npm](https://img.shields.io/npm/dm/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain)
+[![Tests](https://github.com/oblador/react-native-keychain/actions/workflows/tests.yaml/badge.svg)](https://github.com/oblador/react-native-keychain/actions/workflows/tests.yaml) [![npm](https://img.shields.io/npm/v/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain) [![npm](https://img.shields.io/npm/dm/react-native-keychain.svg)](https://npmjs.com/package/react-native-keychain)
 
 # Keychain/Keystore Access for React Native
 


### PR DESCRIPTION
It seems Travis is no more in use:

<img width="327" alt="image" src="https://github.com/user-attachments/assets/1da2083f-9f42-4365-b29f-6427628ef603">


Since it was linking the test CI:
https://github.com/oblador/react-native-keychain/pull/97/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485

I updated the badge with the related GHA badge.