### PR TITLE
fix: standarize hasInternetCredentials

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -371,10 +371,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       promise.resolve(false)
       return
     }
-    val results = Arguments.createMap()
-    results.putString(Maps.SERVICE, alias)
-    results.putString(Maps.STORAGE, resultSet.cipherStorageName)
-    promise.resolve(results)
+    promise.resolve(true)
   }
 
   @ReactMethod

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ export function getAllGenericPasswordServices(): Promise<string[]> {
  *
  * @param {string} server - The server URL.
  *
- * @returns {Promise<false | true>} Resolves to `true` if internet credentials exist, otherwise `false`.
+ * @returns {Promise<boolean>} Resolves to `true` if internet credentials exist, otherwise `false`.
  *
  * @example
  * ```typescript
@@ -355,7 +355,7 @@ export function getAllGenericPasswordServices(): Promise<string[]> {
  * console.log('Internet credentials exist:', hasCredentials);
  * ```
  */
-export function hasInternetCredentials(server: string): Promise<false | true> {
+export function hasInternetCredentials(server: string): Promise<boolean> {
   return RNKeychainManager.hasInternetCredentialsForServer(server);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ export function getAllGenericPasswordServices(): Promise<string[]> {
  *
  * @param {string} server - The server URL.
  *
- * @returns {Promise<false | Result>} Resolves to an object containing `service` and `storage` when successful, or `false` if not found.
+ * @returns {Promise<false | true>} Resolves to `true` if internet credentials exist, otherwise `false`.
  *
  * @example
  * ```typescript
@@ -355,9 +355,7 @@ export function getAllGenericPasswordServices(): Promise<string[]> {
  * console.log('Internet credentials exist:', hasCredentials);
  * ```
  */
-export function hasInternetCredentials(
-  server: string
-): Promise<false | Result> {
+export function hasInternetCredentials(server: string): Promise<false | true> {
   return RNKeychainManager.hasInternetCredentialsForServer(server);
 }
 


### PR DESCRIPTION
Fixes #479
We can't return a Result for iOS, so we should return only true or false to make this method the same across all platforms.
This change will also make the method consistent with the hasGenericPassword method, which also returns true or false.