### PR TITLE
Default value for authenticationPrompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,9 +46,7 @@ export function setGenericPassword(
   password: string,
   serviceOrOptions?: string | SetOptions
 ): Promise<false | Result> {
-  const options = normalizeStorageOptions(
-    normalizeServiceOption(serviceOrOptions)
-  );
+  const options = normalizeStorageOptions(normalizeOptions(serviceOrOptions));
   return RNKeychainManager.setGenericPasswordForOptions(
     options,
     username,
@@ -180,7 +178,7 @@ export function setInternetCredentials(
     server,
     username,
     password,
-    options ? normalizeStorageOptions(options) : {}
+    normalizeStorageOptions(normalizeOptions(options))
   );
 }
 


### PR DESCRIPTION
If no value is passed for authenticationPrompt when settings internet credentials or generic password it throws an error: `Title must be set and non-empty`. This is a breaking change since v8.