### PR TITLE
fix: authenticationPrompt for SetOptions

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -594,7 +594,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
         useBiometry && (isFingerprintAuthAvailable || isFaceAuthAvailable || isIrisAuthAvailable)
     var foundCipher: CipherStorage? = null
     for (variant in cipherStorageMap.values) {
-      Log.d(KEYCHAIN_MODULE, "Probe cipher storage: " + variant.javaClass.simpleName)
+      Log.d(KEYCHAIN_MODULE, "Probe cipher storage: " + variant.getCipherStorageName())
 
       // Is the cipherStorage supported on the current API level?
       val minApiLevel = variant.getMinSupportedApiLevel()
@@ -616,7 +616,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
     if (foundCipher == null) {
       throw CryptoFailedException("Unsupported Android SDK " + Build.VERSION.SDK_INT)
     }
-    Log.d(KEYCHAIN_MODULE, "Selected storage: " + foundCipher.javaClass.simpleName)
+    Log.d(KEYCHAIN_MODULE, "Selected storage: " + foundCipher.getCipherStorageName())
     return foundCipher
   }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
@@ -1,12 +1,12 @@
 package com.oblador.keychain.cipherStorage
 
-import android.annotation.TargetApi
 import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyInfo
 import android.security.keystore.KeyProperties
 import android.security.keystore.UserNotAuthenticatedException
 import android.util.Log
+import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.ReactApplicationContext
 import com.oblador.keychain.KeychainModule.KnownCiphers
 import com.oblador.keychain.SecurityLevel
@@ -26,8 +26,8 @@ import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 
-@TargetApi(Build.VERSION_CODES.M)
-class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, val requiresBiometricAuth: Boolean) :
+@RequiresApi(Build.VERSION_CODES.M)
+class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, private val requiresBiometricAuth: Boolean) :
     CipherStorageBase(reactContext) {
 
     // region Constants

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
@@ -1,12 +1,12 @@
 package com.oblador.keychain.cipherStorage
 
+import android.annotation.TargetApi
 import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyInfo
 import android.security.keystore.KeyProperties
 import android.security.keystore.UserNotAuthenticatedException
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.ReactApplicationContext
 import com.oblador.keychain.KeychainModule.KnownCiphers
 import com.oblador.keychain.SecurityLevel
@@ -26,7 +26,7 @@ import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 
-@RequiresApi(Build.VERSION_CODES.M)
+@TargetApi(Build.VERSION_CODES.M)
 class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, private val requiresBiometricAuth: Boolean) :
     CipherStorageBase(reactContext) {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import {
   normalizeOptions,
   normalizeServerOption,
   normalizeServiceOption,
-  normalizeStorageOptions,
 } from './normalizeOptions';
 
 const { RNKeychainManager } = NativeModules;
@@ -46,9 +45,7 @@ export function setGenericPassword(
   password: string,
   serviceOrOptions?: string | SetOptions
 ): Promise<false | Result> {
-  const options = normalizeStorageOptions(
-    normalizeServiceOption(serviceOrOptions)
-  );
+  const options = normalizeOptions(serviceOrOptions);
   return RNKeychainManager.setGenericPasswordForOptions(
     options,
     username,
@@ -180,7 +177,7 @@ export function setInternetCredentials(
     server,
     username,
     password,
-    options ? normalizeStorageOptions(options) : {}
+    options ? normalizeOptions(options) : {}
   );
 }
 

--- a/src/normalizeOptions.ts
+++ b/src/normalizeOptions.ts
@@ -1,5 +1,10 @@
 import { STORAGE_TYPE } from './enums';
-import type { AuthenticationPrompt, BaseOptions, SetOptions } from './types';
+import type {
+  AuthenticationPrompt,
+  BaseOptions,
+  GetOptions,
+  SetOptions,
+} from './types';
 
 // Default authentication prompt options
 export const AUTH_PROMPT_DEFAULTS: AuthenticationPrompt = {
@@ -7,8 +12,10 @@ export const AUTH_PROMPT_DEFAULTS: AuthenticationPrompt = {
   cancel: 'Cancel',
 };
 
-export function normalizeStorageOptions(options: SetOptions): SetOptions {
-  if (options.storage && options.storage === STORAGE_TYPE.AES) {
+export function normalizeStorageOptions(
+  options: SetOptions | GetOptions
+): SetOptions {
+  if ('storage' in options && options.storage === STORAGE_TYPE.AES) {
     console.warn(
       `You passed 'AES' as a storage option to one of the react-native-keychain functions.
             This way of passing storage is deprecated and will be removed in a future major.`
@@ -51,12 +58,13 @@ export function normalizeServerOption(
 }
 
 export function normalizeOptions(
-  serviceOrOptions?: string | SetOptions
-): SetOptions {
-  const options = {
+  serviceOrOptions?: string | SetOptions | GetOptions
+): SetOptions | GetOptions {
+  const options = normalizeStorageOptions({
     authenticationPrompt: AUTH_PROMPT_DEFAULTS,
     ...normalizeServiceOption(serviceOrOptions),
-  };
+  });
+
   const { authenticationPrompt } = options;
 
   if (typeof authenticationPrompt === 'string') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,17 @@ export type SetOptions = {
    * @default 'Best available storage'
    */
   storage?: STORAGE_TYPE;
+  /** Authentication prompt details or a title string.
+   * @default
+   * ```json
+   * {
+   *   "title": "Authenticate to retrieve secret",
+   *   "cancel": "Cancel"
+   * }
+   * ```
+   *
+   */
+  authenticationPrompt?: string | AuthenticationPrompt;
 } & BaseOptions &
   AccessControlOption;
 


### PR DESCRIPTION
After introducing the AES_GCM cipherStorage, setGenericOptions for AES_GCM with biometrics now also requires an authenticationPrompt.