### PR TITLE
setInternetCredentials default value for authenticationPrompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ export function setInternetCredentials(
     server,
     username,
     password,
-    options ? normalizeOptions(options) : {}
+    normalizeOptions(options)
   );
 }
 


### PR DESCRIPTION
If no options is passed to setInternetCredentials it will throw an error.