### PR TITLE
fix: IllegalBlockSizeException on Android while decrypting

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
@@ -229,33 +229,6 @@ class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, private
 
     /** Decrypt provided bytes to a string. */
 
-    @Throws(GeneralSecurityException::class, IOException::class)
-    override fun decryptBytes(
-        key: Key,
-        bytes: ByteArray,
-        handler: DecryptBytesHandler?
-    ): String {
-        val cipher = getCachedInstance()
-
-        return try {
-            if (IV.IV_LENGTH >= bytes.size)
-                throw IOException("Insufficient length of input data for IV extracting.")
-            val iv = ByteArray(IV.IV_LENGTH)
-            System.arraycopy(bytes, 0, iv, 0, IV.IV_LENGTH)
-            val spec = GCMParameterSpec(IV.TAG_LENGTH, iv)
-            cipher.init(Cipher.DECRYPT_MODE, key, spec)
-
-            // Decrypt the bytes using cipher.doFinal()
-            val decryptedBytes = cipher.doFinal(bytes, IV.IV_LENGTH, bytes.size - IV.IV_LENGTH)
-            String(decryptedBytes, UTF8)
-        } catch (ex: UserNotAuthenticatedException){
-            throw ex
-        } catch (fail: Throwable) {
-            Log.w(LOG_TAG, fail.message, fail)
-            throw fail
-        }
-    }
-
     // endregion
 
     // region Initialization Vector encrypt/decrypt support


### PR DESCRIPTION
This fixes the javax.crypto.IllegalBlockSizeException that sometimes occurs during decryption.

```
javax.crypto.IllegalBlockSizeException
java.io.IOException: javax.crypto.IllegalBlockSizeException
at javax.crypto.CipherInputStream.getMoreData(CipherInputStream.java:133)
at javax.crypto.CipherInputStream.read(CipherInputStream.java:249)
at javax.crypto.CipherInputStream.read(CipherInputStream.java:225)
```