### PR TITLE
fix: update node engine to >=16

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "node": "16.14.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "codegenConfig": {
     "name": "RNKeychainSpec",


### PR DESCRIPTION
Updated the node engine to >= 16 to make it compatible with Node 16 runtime and to skip using `yarn install --ignore-engines` for node version less than 18