### PR TITLE
Revert "fix: update node engine to >=16"

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "node": "16.14.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "codegenConfig": {
     "name": "RNKeychainSpec",


### PR DESCRIPTION
Reverts oblador/react-native-keychain#702