### PR TITLE
chore: upgrade RNKeychain_kotlinVersion to 2.0.0 in gradle properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
-RNKeychain_kotlinVersion=1.8.0
+RNKeychain_kotlinVersion=2.0.0
 RNKeychain_compileSdkVersion=34
 RNKeychain_targetSdkVersion=34
 RNKeychain_minSdkVersion=21


### PR DESCRIPTION
**Description:**  
This PR resolves compatibility issues caused by `RNKeychain_kotlinVersion`. Upgrading the Kotlin version to `2.0.0` fixes this. 

**Changes Made:**  
- Updated the `RNKeychain_kotlinVersion` in `gradle.properties` to `2.0.0`.

**Reason for the Change:**  
The previous Kotlin version was causing build errors or incompatibilities with other dependencies. Upgrading to `2.0.0` resolves these issues.

**Testing:**  
- Verified the project builds successfully after the update.  

**Checklist:**  
- [x] Project builds successfully after changes.  