### PR TITLE
fix: update Android `react-native` resolution approach in monorepos

### DIFF
--- a/android/react-native-helpers.gradle
+++ b/android/react-native-helpers.gradle
@@ -4,23 +4,17 @@ def safeAppExtGet(prop, fallback) {
 }
 
 // Let's detect react-native's directory, it will be used to determine RN's version
-// https://github.com/software-mansion/react-native-reanimated/blob/cda4627c3337c33674f05f755b7485165c6caca9/android/build.gradle#L88
+// https://github.com/software-mansion/react-native-reanimated/blob/b703185e9f3ea3dfd5247477177820795c6f23ec/packages/react-native-reanimated/android/build.gradle#L73
 def resolveReactNativeDirectory() {
   def reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
   if (reactNativeLocation != null) {
     return file(reactNativeLocation)
   }
 
-  // monorepo workaround
-  // react-native can be hoisted or in project's own node_modules
-  def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
-  if (reactNativeFromProjectNodeModules.exists()) {
-    return reactNativeFromProjectNodeModules
-  }
-
-  def reactNativeFromNodeModules = file("${projectDir}/../../react-native")
-  if (reactNativeFromNodeModules.exists()) {
-    return reactNativeFromNodeModules
+  // Fallback to node resolver for custom directory structures like monorepos.
+  def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+  if(reactNativePackage.exists()) {
+      return reactNativePackage.parentFile
   }
 
   throw new GradleException(


### PR DESCRIPTION
### Description

Update the React Native package resolution in Android for monorepos, aligning with the recent approach used in [`react-native-reanimated`](https://github.com/software-mansion/react-native-reanimated/blob/b703185e9f3ea3dfd5247477177820795c6f23ec/packages/react-native-reanimated/android/build.gradle#L73-L88).

### Rationale

This update introduces a nesting-agnostic resolution approach, making it more adaptable to various monorepo structures. Different projects organize their repositories with varying levels of nesting. For example, in the [`@divvy/mobile`](https://github.com/divvixyz/divvi-mobile) framework, apps are structured within the `/apps` directory rather than at the root. This change ensures better compatibility across different monorepos.