### PR TITLE
fix: typo in serverOrOptions

### DIFF
--- a/src/normalizeOptions.ts
+++ b/src/normalizeOptions.ts
@@ -47,8 +47,8 @@ export function normalizeServerOption(
   if (typeof serverOrOptions === 'string') {
     console.warn(
       `You passed a server string as an argument to one of the react-native-keychain functions.
-            This way of passing service is deprecated and will be removed in a future major.
-            Please update your code to use { service: ${JSON.stringify(
+            This way of passing server is deprecated and will be removed in a future major.
+            Please update your code to use { server: ${JSON.stringify(
               serverOrOptions
             )} }`
     );


### PR DESCRIPTION
the warning message in `normalizeServerOption` says to use

```
{ service: serverOrOptions }
```

but this normalize code handles the `server` options, not the `service` option.

Fixes that typo to make it correct