### PR TITLE
fix: update alias handling in AesGcm to include prefix based on auth requirements

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
@@ -175,7 +175,7 @@ class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, private
 
         val validityDuration = 5
         val keyGenParameterSpecBuilder =
-            KeyGenParameterSpec.Builder(alias, purposes)
+            KeyGenParameterSpec.Builder(getPrefixedAlias(alias), purposes)
                 .setBlockModes(BLOCK_MODE_GCM)
                 .setEncryptionPaddings(PADDING_NONE)
                 .setRandomizedEncryptionRequired(true)
@@ -267,4 +267,14 @@ class CipherStorageKeystoreAesGcm(reactContext: ReactApplicationContext, private
         decryptBytes(key, bytes, IV.decrypt)
 
     // endregion
+
+    // region Alias Helpers
+    
+    private fun getPrefixedAlias(alias: String): String {
+        val prefix = if (requiresBiometricAuth) "bio_" else "std_"
+        return prefix + alias
+    }
+
+    // endregion
+
 }


### PR DESCRIPTION
Fixes - https://github.com/oblador/react-native-keychain/issues/730
if I understood correctly, this issue is caused by bio and non bio auth alias being considered the same.
This prefix solves that issue.
@DorianMazur is also working on a solution but was wondering if this fix would work so I can patch it in asap.


- Adds helper function getPrefixedAlias in CipherStorageKeystoreAesGcm.kt
- Call helper function when setting alias