### PR TITLE
refactor: Improve Cipher Management with Thread-Safe Caching

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
+import com.oblador.keychain.cipherStorage.CipherCache
 import com.oblador.keychain.cipherStorage.CipherStorage
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult
 import com.oblador.keychain.cipherStorage.CipherStorageBase
@@ -156,6 +157,8 @@ class KeychainModule(reactContext: ReactApplicationContext) :
     if (coroutineScope.isActive) {
       coroutineScope.cancel("$KEYCHAIN_MODULE has been destroyed.")
     }
+    // Clean up cipher cache
+    CipherCache.clearCache()
   }
 
   /** {@inheritDoc} */

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherCache.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherCache.kt
@@ -1,0 +1,37 @@
+package com.oblador.keychain.cipherStorage
+
+import android.util.Log
+import java.security.NoSuchAlgorithmException
+import javax.crypto.Cipher
+import javax.crypto.NoSuchPaddingException
+
+object CipherCache {
+    private val LOG_TAG = CipherCache::class.java.simpleName
+
+    private val cipherCache = ThreadLocal<MutableMap<String, Cipher>>()
+
+    @Throws(NoSuchAlgorithmException::class, NoSuchPaddingException::class)
+    fun getCipher(transformation: String): Cipher {
+        var ciphers = cipherCache.get()
+        if (ciphers == null) {
+            ciphers = HashMap()
+            cipherCache.set(ciphers)
+        }
+
+        var cipher = ciphers[transformation]
+        if (cipher == null) {
+            cipher = Cipher.getInstance(transformation)
+            ciphers[transformation] = cipher
+        }
+
+        return cipher
+    }
+
+    fun clearCache() {
+        try {
+            cipherCache.remove()
+        } catch (e: Exception) {
+            Log.w(LOG_TAG, "Failed to clear cipher cache: ${e.message}")
+        }
+    }
+}

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherCache.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherCache.kt
@@ -24,7 +24,7 @@ object CipherCache {
             ciphers[transformation] = cipher
         }
 
-        return cipher
+        return cipher!!
     }
 
     fun clearCache() {

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
@@ -79,10 +79,6 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
 
   // region Members
 
-  /** Get cached instance of cipher. Get instance operation is slow. */
-  @Transient
-  protected var cachedCipher: Cipher? = null
-
   /** Cached instance of the Keystore. */
   @Transient
   protected var cachedKeyStore: KeyStore? = null
@@ -448,23 +444,6 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
     val specification =
       getKeyGenSpecBuilder(alias).setIsStrongBoxBacked(true).build()
     return generateKey(specification)
-  }
-
-  // endregion
-
-  // region Testing
-
-  /** Override internal cipher instance cache. */
-  @VisibleForTesting
-  fun setCipher(cipher: Cipher): CipherStorageBase {
-    return this
-  }
-
-  /** Override the keystore instance cache. */
-  @VisibleForTesting
-  fun setKeyStore(keystore: KeyStore): CipherStorageBase {
-    cachedKeyStore = keystore
-    return this
   }
 
   // endregion

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
@@ -164,14 +164,7 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
   /** Get cipher instance and cache it for any next call. */
   @Throws(NoSuchAlgorithmException::class, NoSuchPaddingException::class)
   fun getCachedInstance(): Cipher {
-    if (cachedCipher == null) {
-      synchronized(this) {
-        if (cachedCipher == null) {
-          cachedCipher = Cipher.getInstance(getEncryptionTransformation())
-        }
-      }
-    }
-    return cachedCipher!!
+    return CipherCache.getCipher(getEncryptionTransformation())
   }
 
   /** Check requirements to the security level. */
@@ -464,7 +457,6 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
   /** Override internal cipher instance cache. */
   @VisibleForTesting
   fun setCipher(cipher: Cipher): CipherStorageBase {
-    cachedCipher = cipher
     return this
   }
 

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAesGcm.kt
@@ -66,7 +66,7 @@ class CipherStorageKeystoreAesGcm(
     /** AES. */
     override fun getEncryptionAlgorithm(): String = ALGORITHM_AES
 
-    /** AES/CBC/PKCS7Padding */
+    /** AES/GCM/NoPadding */
     override fun getEncryptionTransformation(): String = ENCRYPTION_TRANSFORMATION
 
     // endregion


### PR DESCRIPTION
# Improve Cipher Management with Thread-Safe Caching and Potential Fix for AEADBadTagException

## Summary

This PR improves the management of `Cipher` instances by implementing a new `CipherCache` utility with ThreadLocal-based caching. These changes enhance thread safety, and might help mitigate potential causes of [AEADBadTagException](https://github.com/oblador/react-native-keychain/issues/730). By eliminating shared mutable state, ensuring proper reinitialisation, and cleaning up cached resources, the PR addresses issues such as state leakage that can lead to authentication tag mismatches.

## Changes

- **New CipherCache Utility:**
  - Implemented a new `CipherCache` singleton with ThreadLocal storage to manage `Cipher` instances.
  - Ciphers are cached per transformation string to support different configurations.
- **Thread-Safe Caching:**
  - Replaced the old single-instance caching mechanism in `CipherStorageBase` with ThreadLocal-based caching.
  - Each thread now has its own isolated `Cipher` instance, eliminating synchronisation bottlenecks.
- **Cleanup and Memory Leak Prevention:**
  - Added proper cleanup of cached `Cipher` instances on module invalidation (e.g., in `KeychainModule.invalidate()`).
  - Fixed potential memory leaks by cleaning up ThreadLocal references.
- **Potential AEADBadTagException Mitigation:**
  - Improved cipher initialisation performance and state management ensure that each `Cipher` is reinitialised with the correct parameters (key, IV, etc.) before use.
  - Isolated cipher instances per thread help mitigate errors from concurrent use that can lead to AEADBadTagException.

## Technical Details

- **CipherCache Implementation:**
  - Uses `ThreadLocal<MutableMap<String, Cipher>>` keyed by transformation string.
  - Each thread has its own cache, ensuring that `Cipher` instances are not shared across threads.
- **Proper Reinitialisation:**
  - Cached `Cipher` instances must be reinitialised (via `cipher.init(...)`) before each operation to clear any previous state.
- **Resource Cleanup:**
  - The new cleanup method in `KeychainModule.invalidate()` clears the ThreadLocal cache to prevent memory leaks, especially in long-lived thread environments.
- **Removal of Old Caching Mechanism:**
  - The previous single-instance caching in `CipherStorageBase` has been removed to avoid shared mutable state.
  