### PR TITLE
fix: add error handling in decryptBytes to throw CryptoFailedException for AEADBadTagException

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
@@ -339,7 +339,7 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
 
   /** Decrypt provided bytes to a string. */
   @SuppressLint("NewApi")
-  @Throws(GeneralSecurityException::class, IOException::class)
+  @Throws(GeneralSecurityException::class, IOException::class, CryptoFailedException::class)
   protected open fun decryptBytes(
     key: Key,
     bytes: ByteArray,
@@ -361,7 +361,14 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
                 e.cause?.message?.contains("Key user not authenticated") == true -> {
                 throw UserNotAuthenticatedException()
               }
-
+              e is javax.crypto.AEADBadTagException -> {
+                throw CryptoFailedException(
+                  "Decryption failed: Authentication tag verification failed. " +
+                  "This usually indicates that the encrypted data was modified, corrupted, " +
+                  "or is being decrypted with the wrong key.",
+                  e
+                )
+              }
               else -> throw e
             }
           }


### PR DESCRIPTION
# Description

Improves error handling for cryptographic operations by adding specific handling for `AEADBadTagException`. This exception occurs during AES-GCM decryption when the authentication tag verification fails, indicating possible data corruption or tampering.

currently unhandled: https://github.com/oblador/react-native-keychain/issues/730

## Changes

- Added explicit handling for `javax.crypto.AEADBadTagException` in `CipherStorageBase`
- Improved error message to better describe the cause and potential solutions
- Added `CryptoFailedException` to `@Throws` annotation 

## Error Message Changes
Previous generic error handling is now replaced with a specific message for authentication failures:
"Decryption failed: Authentication tag verification failed. This usually indicates that the encrypted data was modified, corrupted, or is being decrypted with the wrong key."

Only improves error handling and messaging.