### PR TITLE
test: e2e - add helpers for entering passcode / biometrics

### DIFF
--- a/KeychainExample/e2e/testCases/accessControlTest.spec.js
+++ b/KeychainExample/e2e/testCases/accessControlTest.spec.js
@@ -12,6 +12,39 @@ describe('Access Control', () => {
   });
   ['genericPassword', 'internetCredentials'].forEach((type) => {
     it(
+      ':android:should save and retrieve username and password with passcode - ' +
+        type,
+      async () => {
+        await expect(element(by.text('Keychain Example'))).toExist();
+        await element(by.id('usernameInput')).typeText('testUsernamePasscode');
+        await element(by.id('passwordInput')).typeText('testPasswordPasscode');
+        // Hide keyboard
+        await element(by.text('Keychain Example')).tap();
+        await element(by.text('Passcode')).tap();
+
+        await expect(element(by.text('Save'))).toBeVisible();
+
+        await element(by.text('Save')).tap();
+        await enterPasscode();
+        // Hide keyboard if open
+        await element(by.text('Keychain Example')).tap();
+        await waitFor(element(by.text(/^Credentials saved! .*$/)))
+          .toExist()
+          .withTimeout(4000);
+
+        await waitForAuthValidity();
+        await element(by.text('Load')).tap();
+        await enterPasscode();
+        // Hide keyboard if open
+        await element(by.text('Keychain Example')).tap();
+        await matchLoadInfo(
+          'testUsernamePasscode',
+          'testPasswordPasscode',
+          'KeystoreAESGCM'
+        );
+      }
+    );
+    it(
       ' should save and retrieve username and password with biometrics - ' +
         type,
       async () => {
@@ -59,36 +92,6 @@ describe('Access Control', () => {
         await element(by.text('Load')).tap();
         await enterBiometrics();
         await matchLoadInfo('testUsernameBiometrics', 'testPasswordBiometrics');
-      }
-    );
-
-    it(
-      ':android:should save and retrieve username and password with passcode - ' +
-        type,
-      async () => {
-        await expect(element(by.text('Keychain Example'))).toExist();
-        await element(by.id('usernameInput')).typeText('testUsernamePasscode');
-        await element(by.id('passwordInput')).typeText('testPasswordPasscode');
-        // Hide keyboard
-        await element(by.text('Keychain Example')).tap();
-        await element(by.text('Passcode')).tap();
-
-        await expect(element(by.text('Save'))).toBeVisible();
-
-        await element(by.text('Save')).tap();
-        await enterPasscode();
-        await waitFor(element(by.text(/^Credentials saved! .*$/)))
-          .toExist()
-          .withTimeout(4000);
-
-        await waitForAuthValidity();
-        await element(by.text('Load')).tap();
-        await enterPasscode();
-        await matchLoadInfo(
-          'testUsernamePasscode',
-          'testPasswordPasscode',
-          'KeystoreAESGCM'
-        );
       }
     );
 

--- a/KeychainExample/e2e/testCases/accessControlTest.spec.js
+++ b/KeychainExample/e2e/testCases/accessControlTest.spec.js
@@ -36,7 +36,7 @@ describe('Access Control', () => {
         await element(by.text('Save')).tap();
         await enterBiometrics();
 
-        await expect(element(by.text(/^Credentials saved! .*$/)))
+        await waitFor(element(by.text(/^Credentials saved! .*$/)))
           .toExist()
           .withTimeout(3000);
 
@@ -77,7 +77,7 @@ describe('Access Control', () => {
 
         await element(by.text('Save')).tap();
         await enterPasscode();
-        await expect(element(by.text(/^Credentials saved! .*$/)))
+        await waitFor(element(by.text(/^Credentials saved! .*$/)))
           .toExist()
           .withTimeout(3000);
 

--- a/KeychainExample/e2e/testCases/accessControlTest.spec.js
+++ b/KeychainExample/e2e/testCases/accessControlTest.spec.js
@@ -79,7 +79,7 @@ describe('Access Control', () => {
         await enterPasscode();
         await waitFor(element(by.text(/^Credentials saved! .*$/)))
           .toExist()
-          .withTimeout(3000);
+          .withTimeout(4000);
 
         await waitForAuthValidity();
         await element(by.text('Load')).tap();

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -1,6 +1,6 @@
 import { by, device, element, expect } from 'detox';
 import { matchLoadInfo } from '../utils/matchLoadInfo';
-import cp from 'child_process';
+import { enterBiometrics } from '../utils/authHelpers';
 
 describe(':android:Storage Types', () => {
   beforeEach(async () => {
@@ -42,15 +42,11 @@ describe(':android:Storage Types', () => {
       await element(by.text('AES_GCM')).tap();
 
       await expect(element(by.text('Save'))).toBeVisible();
-      setTimeout(() => {
-        cp.spawnSync('adb', ['-e', 'emu', 'finger', 'touch', '1']);
-      }, 1000);
       await element(by.text('Save')).tap();
+      await enterBiometrics();
       await expect(element(by.text(/^Credentials saved! .*$/))).toBeVisible();
-      setTimeout(() => {
-        cp.spawnSync('adb', ['-e', 'emu', 'finger', 'touch', '1']);
-      }, 1000);
       await element(by.text('Load')).tap();
+      await enterBiometrics();
       await matchLoadInfo(
         'testUsernameAESGCM',
         'testPasswordAESGCM',
@@ -103,10 +99,8 @@ describe(':android:Storage Types', () => {
       await expect(element(by.text('Save'))).toBeVisible();
       await element(by.text('Save')).tap();
       await expect(element(by.text(/^Credentials saved! .*$/))).toBeVisible();
-      setTimeout(() => {
-        cp.spawnSync('adb', ['-e', 'emu', 'finger', 'touch', '1']);
-      }, 1000);
       await element(by.text('Load')).tap();
+      await enterBiometrics();
       await expect(element(by.text(/^Credentials loaded! .*$/))).toBeVisible();
       await matchLoadInfo(
         'testUsernameRSA',

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -1,6 +1,6 @@
 import { by, device, element, expect } from 'detox';
 import { matchLoadInfo } from '../utils/matchLoadInfo';
-import { enterBiometrics } from '../utils/authHelpers';
+import { enterBiometrics, waitForAuthValidity } from '../utils/authHelpers';
 
 describe(':android:Storage Types', () => {
   beforeEach(async () => {
@@ -45,6 +45,7 @@ describe(':android:Storage Types', () => {
       await element(by.text('Save')).tap();
       await enterBiometrics();
       await expect(element(by.text(/^Credentials saved! .*$/))).toBeVisible();
+      await waitForAuthValidity();
       await element(by.text('Load')).tap();
       await enterBiometrics();
       await matchLoadInfo(

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -107,7 +107,7 @@ describe(':android:Storage Types', () => {
       await element(by.text('Save')).tap();
       await waitFor(element(by.text(/^Credentials saved! .*$/)))
         .toExist()
-        .withTimeout(3000);
+        .withTimeout(4000);
       await element(by.text('Load')).tap();
       await enterBiometrics();
       await waitFor(element(by.text(/^Credentials loaded! .*$/)))

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -46,7 +46,7 @@ describe(':android:Storage Types', () => {
       await expect(element(by.text('Save'))).toBeVisible();
       await element(by.text('Save')).tap();
       await enterBiometrics();
-      await expect(element(by.text(/^Credentials saved! .*$/)))
+      await waitFor(element(by.text(/^Credentials saved! .*$/)))
         .toExist()
         .withTimeout(3000);
       await waitForAuthValidity();
@@ -105,7 +105,7 @@ describe(':android:Storage Types', () => {
 
       await expect(element(by.text('Save'))).toBeVisible();
       await element(by.text('Save')).tap();
-      await expect(element(by.text(/^Credentials saved! .*$/)))
+      await waitFor(element(by.text(/^Credentials saved! .*$/)))
         .toExist()
         .withTimeout(3000);
       await element(by.text('Load')).tap();

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -110,9 +110,9 @@ describe(':android:Storage Types', () => {
         .withTimeout(3000);
       await element(by.text('Load')).tap();
       await enterBiometrics();
-      await expect(element(by.text(/^Credentials loaded! .*$/)))
+      await waitFor(element(by.text(/^Credentials loaded! .*$/)))
         .toExist()
-        .withTimeout(3000);
+        .withTimeout(4000);
       await matchLoadInfo(
         'testUsernameRSA',
         'testPasswordRSA',

--- a/KeychainExample/e2e/testCases/storageTypesTest.spec.js
+++ b/KeychainExample/e2e/testCases/storageTypesTest.spec.js
@@ -107,12 +107,12 @@ describe(':android:Storage Types', () => {
       await element(by.text('Save')).tap();
       await waitFor(element(by.text(/^Credentials saved! .*$/)))
         .toExist()
-        .withTimeout(4000);
+        .withTimeout(5000);
       await element(by.text('Load')).tap();
       await enterBiometrics();
       await waitFor(element(by.text(/^Credentials loaded! .*$/)))
         .toExist()
-        .withTimeout(4000);
+        .withTimeout(5000);
       await matchLoadInfo(
         'testUsernameRSA',
         'testPasswordRSA',

--- a/KeychainExample/e2e/utils/authHelpers.js
+++ b/KeychainExample/e2e/utils/authHelpers.js
@@ -20,7 +20,7 @@ export const enterPasscode = async () => {
   if (device.getPlatform() === 'android') {
     await new Promise((resolve) => setTimeout(resolve, 1500));
     cp.spawnSync('adb', ['shell', 'input', 'text', '1111']);
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
     cp.spawnSync('adb', ['shell', 'input', 'keyevent', '66']);
     await new Promise((resolve) => setTimeout(resolve, 500));
   }

--- a/KeychainExample/e2e/utils/authHelpers.js
+++ b/KeychainExample/e2e/utils/authHelpers.js
@@ -22,6 +22,6 @@ export const enterPasscode = async () => {
     cp.spawnSync('adb', ['shell', 'input', 'text', '1111']);
     await new Promise((resolve) => setTimeout(resolve, 2000));
     cp.spawnSync('adb', ['shell', 'input', 'keyevent', '66']);
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
   }
 };

--- a/KeychainExample/e2e/utils/authHelpers.js
+++ b/KeychainExample/e2e/utils/authHelpers.js
@@ -1,0 +1,27 @@
+import { device } from 'detox';
+import cp from 'child_process';
+
+// Wait for 5 seconds to ensure auth validity period has expired
+export const waitForAuthValidity = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 5500)); // Added 500ms buffer
+};
+
+export const enterBiometrics = async () => {
+  // Biometric prompt is not available in the IOS simulator
+  // https://github.com/oblador/react-native-keychain/issues/340
+  if (device.getPlatform() === 'android') {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    cp.spawnSync('adb', ['-e', 'emu', 'finger', 'touch', '1']);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+};
+
+export const enterPasscode = async () => {
+  if (device.getPlatform() === 'android') {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    cp.spawnSync('adb', ['shell', 'input', 'text', '1111']);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    cp.spawnSync('adb', ['shell', 'input', 'keyevent', '66']);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+};

--- a/KeychainExample/e2e/utils/matchLoadInfo.ts
+++ b/KeychainExample/e2e/utils/matchLoadInfo.ts
@@ -21,6 +21,6 @@ export const matchLoadInfo = async (
   regexPattern += '.*$';
   const regex = new RegExp(regexPattern);
   await waitFor(element(by.text(regex)))
-    .toBeVisible()
+    .toExist()
     .withTimeout(3000);
 };


### PR DESCRIPTION
### Description:

**Introducing helper functions:**

- waitForAuthValidity to wait for the authentication period to expire.

- enterBiometrics to simulate biometric interaction on Android.

- enterPasscode to simulate passcode entry on Android.

Adding a small buffer to the wait period for reliable test execution.

also corrected typo in file name 