### PR TITLE
Increase min sdk requirement for strongbox

### DIFF
--- a/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt
+++ b/android/src/main/java/com/oblador/keychain/DeviceAvailability.kt
@@ -15,7 +15,7 @@ import androidx.biometric.BiometricManager
 object DeviceAvailability {
 
   fun isStrongboxAvailable(context: Context): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       context.packageManager.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)
     } else {
       false

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
@@ -442,7 +442,7 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
 
   @Throws(GeneralSecurityException::class)
   protected fun tryGenerateStrongBoxSecurityKey(alias: String): Key {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
       throw KeyStoreAccessException(
         "Strong box security keystore is not supported for old API${Build.VERSION.SDK_INT}."
       )

--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.kt
@@ -444,7 +444,7 @@ abstract class CipherStorageBase(protected val applicationContext: Context) : Ci
   protected fun tryGenerateStrongBoxSecurityKey(alias: String): Key {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
       throw KeyStoreAccessException(
-        "Strong box security keystore is not supported for old API${Build.VERSION.SDK_INT}."
+        "Strong box security keystore is only supported on Android 12 (API level 31) or higher. Current API level: ${Build.VERSION.SDK_INT}."
       )
     }
 


### PR DESCRIPTION
### Motivation
Increase the sdk level requirement for strongbox usage from android 9 to android 12 in order to improve performance of low-end devices with old android versions. 

![Image](https://github.com/user-attachments/assets/9e93cc11-e380-4478-815a-4bc236d708bd)

### Security impact
Attestation level drops from STRONGBOX to TRUSTED_ENVIRONMENT on devices where a TEE exists. Keys are still hardware-backed inside TrustZone; risk increase is limited to sophisticated physical side-channel attacks.


From Google docs https://developer.android.com/privacy-and-security/keystore
![Screenshot 2025-05-16 at 14 11 09](https://github.com/user-attachments/assets/4c9e229c-d80b-4b1b-9fdd-f52aa60f247c)