### PR TITLE
feat(android): add confirmationRequired option to authenticationPrompt

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -68,6 +68,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       const val SUBTITLE = "subtitle"
       const val DESCRIPTION = "description"
       const val CANCEL = "cancel"
+      const val CONFIRMATION_REQUIRED = "confirmationRequired"
     }
   }
 
@@ -779,9 +780,14 @@ class KeychainModule(reactContext: ReactApplicationContext) :
           promptInfoBuilder.setNegativeButtonText(it)
         }
       }
-
-      /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using passive biometrics */
-      promptInfoBuilder.setConfirmationRequired(false)
+      // Default is false — no confirmation required unless explicitly set
+      var confirmationRequired = false
+      promptInfoOptionsMap?.let {
+        if (it.hasKey(AuthPromptOptions.CONFIRMATION_REQUIRED)) {
+          confirmationRequired = it.getBoolean(AuthPromptOptions.CONFIRMATION_REQUIRED)
+        }
+      }
+      promptInfoBuilder.setConfirmationRequired(confirmationRequired)
       return promptInfoBuilder.build()
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export type AuthenticationPrompt = {
    * @platform Android
    */
   cancel?: string;
+
+  /** Whether user confirmation (e.g. OK button) is required after authentication.
+   * Default is `false`.
+   * @platform Android
+   */
+  confirmationRequired?: boolean;
 };
 
 export type BaseOptions = {


### PR DESCRIPTION
## 🔥 Feature: Add `confirmationRequired` Option to Android Authentication Prompt

### ✨ Summary

This PR introduces a new optional field `confirmationRequired` in the `authenticationPrompt` config for Android. It allows developers to control whether the user must press an explicit confirmation (OK) button after biometric authentication.

By default, `confirmationRequired` is now set to `false`, enabling a faster, more seamless biometric UX unless explicitly overridden.

---

### ✅ Changes

**Android Native:**
- `KeychainModule.kt`:
  - Reads `confirmationRequired` from `authenticationPrompt`.
  - Applies it to `PromptInfo.Builder.setConfirmationRequired(...)`.
  - **Default is now `false`** (user does **not** need to confirm after authentication unless specified).

**TypeScript Types:**
- Extended `AuthenticationPrompt` type to support:

```ts
confirmationRequired?: boolean;