### PR TITLE
fix: prevent weak biometrics prompt from displaying on Android

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -766,6 +766,9 @@ class KeychainModule(reactContext: ReactApplicationContext) :
         usePasscode ->
           BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
+        useBiometry ->
+          BiometricManager.Authenticators.BIOMETRIC_STRONG
+
         else ->
           null
       }


### PR DESCRIPTION
Fixes #753 

Srt correct allowedAuthenticators for android prompt.
getPromptInfo() now sets BIOMETRIC_STRONG when only biometrics are requested, preventing post-prompt UserNotAuthenticatedException.