### PR TITLE
fix: use kSecAccessControlDevicePasscode as a fallback on IOS

### DIFF
--- a/ios/RNKeychainManager/RNKeychainManager.m
+++ b/ios/RNKeychainManager/RNKeychainManager.m
@@ -216,7 +216,7 @@ SecAccessControlCreateFlags accessControlValue(NSDictionary *options)
       (flags & kSecAccessControlDevicePasscode);
 
   if (requestedBiometric && requestedPasscode) {
-    NSError *error = nil;
+    NSError *aerr = nil;
     BOOL canAuthenticate = [[LAContext new] canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&aerr];
 
     if (!canAuthenticate)


### PR DESCRIPTION
Closes #752

Added an LAContext capability check in SecAccessControlCreateFlags for iOS and visionOS.
If biometric flags are requested but no biometrics are enrolled, we now fall back to kSecAccessControlDevicePasscode.
This avoids Keychain creation failures on devices without Touch ID or Face ID configured.
Behavior remains unchanged when biometrics are available.