### PR TITLE
feat: Keychain items array

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -446,10 +446,8 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       val value = prefs.getString(key, null)
       
       if (value != null) {
-        // Return the value directly to match old format
         promise.resolve(value)
       } else {
-        // Return undefined/null when key doesn't exist
         promise.resolve(null)
       }
     } catch (e: Exception) {
@@ -491,7 +489,6 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       editor.putString(key, value)
       editor.apply()
       
-      // Return the value to match old format
       promise.resolve(value)
     } catch (e: Exception) {
       Log.e(KEYCHAIN_MODULE, "Error setting item for key: ${e.message}", e)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import type {
   SetOptions,
   AuthenticationTypeOption,
   AccessControlOption,
-  GenericCredentialItem,
 } from './types';
 import { normalizeAuthPrompt } from './normalizeOptions';
 
@@ -371,24 +370,24 @@ export function isPasscodeAuthAvailable(): Promise<boolean> {
 
 
 /**
- * Fetches the item object for a specific key.
+ * Fetches the value for a specific key.
  *
  * @param {string} key - The key to retrieve the value for.
- * @param {SetOptions} [options] - A keychain options object.
+ * @param {BaseOptions} [options] - A keychain options object.
  *
- * @returns {Promise<GenericCredentialItem | undefined>} Resolves to the value string when successful, or throws an error if unsuccessful
+ * @returns {Promise<string | null>} Resolves to the value string when successful, or null if not found
  *
  * @example
  * ```typescript
- * const item = await Keychain.getItemForKey('myKey', options);
- * if (item) {
- *   console.log('Item loaded:', item);
+ * const value = await Keychain.getItemForKey('myKey', options);
+ * if (value) {
+ *   console.log('Value loaded:', value);
  * } else {
- *   console.log('No item stored for key');
+ *   console.log('No value stored for key');
  * }
  * ```
  */
-export function getItemForKey(key: string, options: SetOptions): Promise<GenericCredentialItem | undefined> {
+export function getItemForKey(key: string, options?: BaseOptions): Promise<string | null> {
   return RNKeychainManager.getItemForKey(key, options);
 }
 
@@ -396,9 +395,9 @@ export function getItemForKey(key: string, options: SetOptions): Promise<Generic
 /**
  * Gets all items.
  *
- * @param {SetOptions} [options] - A keychain options object.
+ * @param {BaseOptions} [options] - A keychain options object.
  *
- * @returns {Promise<Array<GenericCredentialItem>>} Resolves to an array of items.
+ * @returns {Promise<Record<string, string>>} Resolves to an object with all key-value pairs.
  *
  * @example
  * ```typescript
@@ -406,7 +405,7 @@ export function getItemForKey(key: string, options: SetOptions): Promise<Generic
  * console.log('All items:', items);
  * ```
  */
-export function getAllItems(options: SetOptions): Array<GenericCredentialItem> {
+export function getAllItems(options?: BaseOptions): Promise<Record<string, string>> {
   return RNKeychainManager.getAllItems(options);
 }
 
@@ -416,27 +415,27 @@ export function getAllItems(options: SetOptions): Array<GenericCredentialItem> {
  *
  * @param {string} key - The key to associate with the value.
  * @param {string} value - The value to be saved.
- * @param {SetOptions} [options] - A keychain options object.
+ * @param {BaseOptions} [options] - A keychain options object.
  *
- * @returns {Promise<GenericCredentialItem>} Resolves to a result object when successful
+ * @returns {Promise<string>} Resolves to the stored value when successful
  *
  * @example
  * ```typescript
  * await Keychain.setItemForKey('myKey', 'value', options);
  * ```
  */
-export function setItemForKey(key: string, value: string, options: SetOptions): Promise<GenericCredentialItem> {
+export function setItemForKey(key: string, value: string, options?: BaseOptions): Promise<string> {
   return RNKeychainManager.setItemForKey(key, value, options);
 }
 
 
 /**
- * Removes the generic value for a specific key.
+ * Removes the value for a specific key.
  *
  * @param {string} key - The key to remove.
- * @param {SetOptions} [options] - A keychain options object.
+ * @param {BaseOptions} [options] - A keychain options object.
  *
- * @returns {Promise<boolean>} Resolves to `true` when successful, or throws an error if unsuccessful
+ * @returns {Promise<boolean>} Resolves to `true` when successful
  *
  * @example
  * ```typescript
@@ -444,7 +443,7 @@ export function setItemForKey(key: string, value: string, options: SetOptions): 
  * console.log('Key removed:', success);
  * ```
  */
-export function removeItemForKey(key: string, options: SetOptions): Promise<boolean> {
+export function removeItemForKey(key: string, options?: BaseOptions): Promise<boolean> {
   return RNKeychainManager.removeItemForKey(key, options);
 }
 
@@ -452,9 +451,9 @@ export function removeItemForKey(key: string, options: SetOptions): Promise<bool
 /**
  * Removes all items matching the service.
  *
- * @param {SetOptions} [options] - A keychain options object.
+ * @param {BaseOptions} [options] - A keychain options object.
  *
- * @returns {Promise<boolean>} Resolves to `true` when successful, or throws an error if unsuccessful
+ * @returns {Promise<boolean>} Resolves to `true` when successful
  *
  * @example
  * ```typescript
@@ -462,7 +461,7 @@ export function removeItemForKey(key: string, options: SetOptions): Promise<bool
  * console.log('All items cleared:', success);
  * ```
  */
-export function clearItems(options: SetOptions): Promise<boolean> {
+export function clearItems(options?: BaseOptions): Promise<boolean> {
   return RNKeychainManager.clearItems(options);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,10 +137,3 @@ export type SharedWebCredentials = {
   /** The server associated with the keychain item. */
   server: string;
 } & UserCredentials;
-
-export type GenericCredentialItem = {
-  /** The key associated with the generic password item. */
-  key: string;
-  /** The password value associated with the generic password item. */
-  value: string;
-} & Result;


### PR DESCRIPTION
This MR makes it possible to store an array of items in the keychain.

**Reason for MR**

I am raising this MR because I wanted to migrate our project from using `react-native-sensitive-info` to using `react-native-keychain`. This repo is actually maintained and has a larger community using it. Also the sensitive info library seems to stop working after upgrading RN `0.76.1+` https://github.com/mCodex/react-native-sensitive-info/issues/424#issuecomment-2511187606. So, time to move on!

However, during testing I found that this library only returns a single object from the keychain. Which seems to be intended looking at comments here: https://github.com/oblador/react-native-keychain/issues/36#issuecomment-329202738, I should be serialising my data structure and storing it as a string in this single object.

This would be fine if I was starting a new project, but losing access to data already in the keychain was not acceptable as we would lose important login keys etc. So I decided to convert the functionality over to this library. Hopefully this will help others convert to this library and add some nice new functionality for existing users.

**Changes**

I have added these functions: `getItemForKey` `getAllItems` `setItemForKey` `removeItemForKey` `clearItems`.

Of course a requirement for me was to mirror as best as possible the behaviour of the functions in `react-native-sensitive-info`. So I can preserve my data after migrating to this library.

I feel like the iOS implementation fits in nicely with the existing code. But I will admit that the Android side was more complex, you guys have a `DataStorePrefsStorage` class that I wasn't sure how exactly to integrate with, so I played it safe and kept to a simple implementation within the main `KeychainModule`. Would appreciate any pointers for this.

Thanks and any feedback is welcome 🙏 
