### PR TITLE
feat: Add KeychainError

### DIFF
--- a/src/KeychainError.ts
+++ b/src/KeychainError.ts
@@ -1,4 +1,5 @@
 import { ERROR_CODE } from './enums';
+
 /**
  * Custom error class for encapsulating the native error objects.
  */

--- a/src/KeychainError.ts
+++ b/src/KeychainError.ts
@@ -1,41 +1,28 @@
 import { ERROR_CODE } from './enums';
-
-interface NativeErrorObject {
-  code: ERROR_CODE;
-  message: string;
-}
-
-const isNativeErrorObject = (err: unknown): err is NativeErrorObject => {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-
-  return "code" in err && "message" in err;
-};
-
 /**
  * Custom error class for encapsulating the native error objects.
  */
-class KeychainError extends Error {
+export class KeychainError extends Error {
   readonly code: ERROR_CODE;
+  readonly cause: Error | null;
 
-  constructor(message: string, code: ERROR_CODE) {
+  constructor(message: string, code: ERROR_CODE, cause?: Error) {
     super(message);
 
     this.name = 'KeychainError';
     this.code = code;
+    this.cause = cause ?? null;
   }
 
   static parse(err: unknown) {
     if (err instanceof Error) {
-      return err;
+      const code =
+        'code' in err ? (err.code as ERROR_CODE) : ERROR_CODE.INTERNAL_ERROR;
+
+      return new KeychainError(err.message, code, err);
     }
 
-    if (isNativeErrorObject(err)) {
-      return new KeychainError(err.message, err.code);
-    }
-
-    return new KeychainError('An unknown error occurred', ERROR_CODE.INTERNAL_ERROR);
+    return err;
   }
 }
 

--- a/src/KeychainError.ts
+++ b/src/KeychainError.ts
@@ -1,0 +1,42 @@
+import { ERROR_CODE } from './enums';
+
+interface NativeErrorObject {
+  code: ERROR_CODE;
+  message: string;
+}
+
+const isNativeErrorObject = (err: unknown): err is NativeErrorObject => {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+
+  return "code" in err && "message" in err;
+};
+
+/**
+ * Custom error class for encapsulating the native error objects.
+ */
+class KeychainError extends Error {
+  readonly code: ERROR_CODE;
+
+  constructor(message: string, code: ERROR_CODE) {
+    super(message);
+
+    this.name = 'KeychainError';
+    this.code = code;
+  }
+
+  static parse(err: unknown) {
+    if (err instanceof Error) {
+      return err;
+    }
+
+    if (isNativeErrorObject(err)) {
+      return new KeychainError(err.message, err.code);
+    }
+
+    return new KeychainError('An unknown error occurred', ERROR_CODE.INTERNAL_ERROR);
+  }
+}
+
+export default KeychainError;

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,6 +437,7 @@ export async function isPasscodeAuthAvailable(): Promise<boolean> {
 
 export * from './enums';
 export * from './types';
+export * from './KeychainError';
 /** @ignore */
 export default {
   SECURITY_LEVEL,
@@ -446,6 +447,7 @@ export default {
   BIOMETRY_TYPE,
   STORAGE_TYPE,
   ERROR_CODE,
+  KeychainError,
   getSecurityLevel,
   canImplyAuthentication,
   getSupportedBiometryType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import type {
   AuthenticationTypeOption,
   AccessControlOption,
 } from './types';
+import KeychainError from './KeychainError';
 import { normalizeAuthPrompt } from './normalizeOptions';
 
 const { RNKeychainManager } = NativeModules;
@@ -37,16 +38,20 @@ const { RNKeychainManager } = NativeModules;
  * await Keychain.setGenericPassword('username', 'password');
  * ```
  */
-export function setGenericPassword(
+export async function setGenericPassword(
   username: string,
   password: string,
   options?: SetOptions
 ): Promise<false | Result> {
-  return RNKeychainManager.setGenericPasswordForOptions(
-    normalizeAuthPrompt(options),
-    username,
-    password
-  );
+  try {
+    return RNKeychainManager.setGenericPasswordForOptions(
+      normalizeAuthPrompt(options),
+      username,
+      password
+    )
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -66,12 +71,16 @@ export function setGenericPassword(
  * }
  * ```
  */
-export function getGenericPassword(
+export async function getGenericPassword(
   options?: GetOptions
 ): Promise<false | UserCredentials> {
-  return RNKeychainManager.getGenericPasswordForOptions(
-    normalizeAuthPrompt(options)
-  );
+  try {
+    return RNKeychainManager.getGenericPasswordForOptions(
+      normalizeAuthPrompt(options)
+    );
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -87,8 +96,12 @@ export function getGenericPassword(
  * console.log('Password exists:', hasPassword);
  * ```
  */
-export function hasGenericPassword(options?: BaseOptions): Promise<boolean> {
-  return RNKeychainManager.hasGenericPasswordForOptions(options);
+export async function hasGenericPassword(options?: BaseOptions): Promise<boolean> {
+  try {
+    return RNKeychainManager.hasGenericPasswordForOptions(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -104,8 +117,12 @@ export function hasGenericPassword(options?: BaseOptions): Promise<boolean> {
  * console.log('Password reset successful:', success);
  * ```
  */
-export function resetGenericPassword(options?: BaseOptions): Promise<boolean> {
-  return RNKeychainManager.resetGenericPasswordForOptions(options);
+export async function resetGenericPassword(options?: BaseOptions): Promise<boolean> {
+  try {
+    return RNKeychainManager.resetGenericPasswordForOptions(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -119,10 +136,14 @@ export function resetGenericPassword(options?: BaseOptions): Promise<boolean> {
  * console.log('Services:', services);
  * ```
  */
-export function getAllGenericPasswordServices(
+export async function getAllGenericPasswordServices(
   options?: GetAllOptions
 ): Promise<string[]> {
-  return RNKeychainManager.getAllGenericPasswordServices(options);
+  try {
+    return RNKeychainManager.getAllGenericPasswordServices(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -138,10 +159,14 @@ export function getAllGenericPasswordServices(
  * console.log('Internet credentials exist:', hasCredentials);
  * ```
  */
-export function hasInternetCredentials(
+export async function hasInternetCredentials(
   options: string | BaseOptions
 ): Promise<boolean> {
-  return RNKeychainManager.hasInternetCredentialsForOptions(options);
+  try {
+    return RNKeychainManager.hasInternetCredentialsForOptions(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -159,18 +184,22 @@ export function hasInternetCredentials(
  * await Keychain.setInternetCredentials('https://example.com', 'username', 'password');
  * ```
  */
-export function setInternetCredentials(
+export async function setInternetCredentials(
   server: string,
   username: string,
   password: string,
   options?: SetOptions
 ): Promise<false | Result> {
-  return RNKeychainManager.setInternetCredentialsForServer(
-    server,
-    username,
-    password,
-    normalizeAuthPrompt(options)
-  );
+  try {
+    return RNKeychainManager.setInternetCredentialsForServer(
+      server,
+      username,
+      password,
+      normalizeAuthPrompt(options)
+    );
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -191,14 +220,18 @@ export function setInternetCredentials(
  * }
  * ```
  */
-export function getInternetCredentials(
+export async function getInternetCredentials(
   server: string,
   options?: GetOptions
 ): Promise<false | UserCredentials> {
-  return RNKeychainManager.getInternetCredentialsForServer(
-    server,
-    normalizeAuthPrompt(options)
-  );
+  try {
+    return RNKeychainManager.getInternetCredentialsForServer(
+      server,
+      normalizeAuthPrompt(options)
+    );
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -214,8 +247,12 @@ export function getInternetCredentials(
  * console.log('Credentials reset for server');
  * ```
  */
-export function resetInternetCredentials(options: BaseOptions): Promise<void> {
-  return RNKeychainManager.resetInternetCredentialsForOptions(options);
+export async function resetInternetCredentials(options: BaseOptions): Promise<void> {
+  try {
+    return RNKeychainManager.resetInternetCredentialsForOptions(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -229,12 +266,16 @@ export function resetInternetCredentials(options: BaseOptions): Promise<void> {
  * console.log('Supported Biometry Type:', biometryType);
  * ```
  */
-export function getSupportedBiometryType(): Promise<null | BIOMETRY_TYPE> {
-  if (!RNKeychainManager.getSupportedBiometryType) {
-    return Promise.resolve(null);
-  }
+export async function getSupportedBiometryType(): Promise<null | BIOMETRY_TYPE> {
+  try {
+    if (!RNKeychainManager.getSupportedBiometryType) {
+      return Promise.resolve(null);
+    }
 
-  return RNKeychainManager.getSupportedBiometryType();
+    return RNKeychainManager.getSupportedBiometryType();
+  } catch (err) {
+    throw KeychainError.parse(err);
+  }
 }
 
 /**
@@ -254,17 +295,22 @@ export function getSupportedBiometryType(): Promise<null | BIOMETRY_TYPE> {
  * }
  * ```
  */
-export function requestSharedWebCredentials(): Promise<
+export async function requestSharedWebCredentials(): Promise<
   false | SharedWebCredentials
 > {
-  if (Platform.OS !== 'ios') {
-    return Promise.reject(
-      new Error(
-        `requestSharedWebCredentials() is not supported on ${Platform.OS} yet`
-      )
-    );
+  try {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error(
+          `requestSharedWebCredentials() is not supported on ${Platform.OS} yet`
+        )
+      );
+    }
+
+    return RNKeychainManager.requestSharedWebCredentials();
+  } catch (err) {
+    throw KeychainError.parse(err);
   }
-  return RNKeychainManager.requestSharedWebCredentials();
 }
 
 /**
@@ -284,23 +330,28 @@ export function requestSharedWebCredentials(): Promise<
  * console.log('Shared web credentials set');
  * ```
  */
-export function setSharedWebCredentials(
+export async function setSharedWebCredentials(
   server: string,
   username: string,
   password?: string
 ): Promise<void> {
-  if (Platform.OS !== 'ios') {
-    return Promise.reject(
-      new Error(
-        `setSharedWebCredentials() is not supported on ${Platform.OS} yet`
-      )
+  try {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error(
+          `setSharedWebCredentials() is not supported on ${Platform.OS} yet`
+        )
+      );
+    }
+
+    return RNKeychainManager.setSharedWebCredentialsForServer(
+      server,
+      username,
+      password
     );
+  } catch (err) {
+    throw KeychainError.parse(err);
   }
-  return RNKeychainManager.setSharedWebCredentialsForServer(
-    server,
-    username,
-    password
-  );
 }
 
 /**
@@ -318,13 +369,18 @@ export function setSharedWebCredentials(
  * console.log('Can imply authentication:', canAuthenticate);
  * ```
  */
-export function canImplyAuthentication(
+export async function canImplyAuthentication(
   options?: AuthenticationTypeOption
 ): Promise<boolean> {
-  if (!RNKeychainManager.canCheckAuthentication) {
-    return Promise.resolve(false);
+  try {
+    if (!RNKeychainManager.canCheckAuthentication) {
+      return Promise.resolve(false);
+    }
+
+    return RNKeychainManager.canCheckAuthentication(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
   }
-  return RNKeychainManager.canCheckAuthentication(options);
 }
 
 /**
@@ -342,13 +398,18 @@ export function canImplyAuthentication(
  * console.log('Security Level:', securityLevel);
  * ```
  */
-export function getSecurityLevel(
+export async function getSecurityLevel(
   options?: AccessControlOption
 ): Promise<null | SECURITY_LEVEL> {
-  if (!RNKeychainManager.getSecurityLevel) {
-    return Promise.resolve(null);
+  try {
+    if (!RNKeychainManager.getSecurityLevel) {
+      return Promise.resolve(null);
+    }
+
+    return RNKeychainManager.getSecurityLevel(options);
+  } catch (err) {
+    throw KeychainError.parse(err);
   }
-  return RNKeychainManager.getSecurityLevel(options);
 }
 
 /**
@@ -362,11 +423,16 @@ export function getSecurityLevel(
  * console.log('Passcode authentication available:', isAvailable);
  * ```
  */
-export function isPasscodeAuthAvailable(): Promise<boolean> {
-  if (!RNKeychainManager.isPasscodeAuthAvailable) {
-    return Promise.resolve(false);
+export async function isPasscodeAuthAvailable(): Promise<boolean> {
+  try {
+    if (!RNKeychainManager.isPasscodeAuthAvailable) {
+      return Promise.resolve(false);
+    }
+
+    return RNKeychainManager.isPasscodeAuthAvailable();
+  } catch (err) {
+    throw KeychainError.parse(err);
   }
-  return RNKeychainManager.isPasscodeAuthAvailable();
 }
 
 export * from './enums';

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,11 @@ export async function setGenericPassword(
   options?: SetOptions
 ): Promise<false | Result> {
   try {
-    return RNKeychainManager.setGenericPasswordForOptions(
+    return await RNKeychainManager.setGenericPasswordForOptions(
       normalizeAuthPrompt(options),
       username,
       password
-    )
+    );
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -75,7 +75,7 @@ export async function getGenericPassword(
   options?: GetOptions
 ): Promise<false | UserCredentials> {
   try {
-    return RNKeychainManager.getGenericPasswordForOptions(
+    return await RNKeychainManager.getGenericPasswordForOptions(
       normalizeAuthPrompt(options)
     );
   } catch (err) {
@@ -96,9 +96,11 @@ export async function getGenericPassword(
  * console.log('Password exists:', hasPassword);
  * ```
  */
-export async function hasGenericPassword(options?: BaseOptions): Promise<boolean> {
+export async function hasGenericPassword(
+  options?: BaseOptions
+): Promise<boolean> {
   try {
-    return RNKeychainManager.hasGenericPasswordForOptions(options);
+    return await RNKeychainManager.hasGenericPasswordForOptions(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -117,9 +119,11 @@ export async function hasGenericPassword(options?: BaseOptions): Promise<boolean
  * console.log('Password reset successful:', success);
  * ```
  */
-export async function resetGenericPassword(options?: BaseOptions): Promise<boolean> {
+export async function resetGenericPassword(
+  options?: BaseOptions
+): Promise<boolean> {
   try {
-    return RNKeychainManager.resetGenericPasswordForOptions(options);
+    return await RNKeychainManager.resetGenericPasswordForOptions(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -140,7 +144,7 @@ export async function getAllGenericPasswordServices(
   options?: GetAllOptions
 ): Promise<string[]> {
   try {
-    return RNKeychainManager.getAllGenericPasswordServices(options);
+    return await RNKeychainManager.getAllGenericPasswordServices(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -163,7 +167,7 @@ export async function hasInternetCredentials(
   options: string | BaseOptions
 ): Promise<boolean> {
   try {
-    return RNKeychainManager.hasInternetCredentialsForOptions(options);
+    return await RNKeychainManager.hasInternetCredentialsForOptions(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -191,7 +195,7 @@ export async function setInternetCredentials(
   options?: SetOptions
 ): Promise<false | Result> {
   try {
-    return RNKeychainManager.setInternetCredentialsForServer(
+    return await RNKeychainManager.setInternetCredentialsForServer(
       server,
       username,
       password,
@@ -225,7 +229,7 @@ export async function getInternetCredentials(
   options?: GetOptions
 ): Promise<false | UserCredentials> {
   try {
-    return RNKeychainManager.getInternetCredentialsForServer(
+    return await RNKeychainManager.getInternetCredentialsForServer(
       server,
       normalizeAuthPrompt(options)
     );
@@ -247,9 +251,11 @@ export async function getInternetCredentials(
  * console.log('Credentials reset for server');
  * ```
  */
-export async function resetInternetCredentials(options: BaseOptions): Promise<void> {
+export async function resetInternetCredentials(
+  options: BaseOptions
+): Promise<void> {
   try {
-    return RNKeychainManager.resetInternetCredentialsForOptions(options);
+    return await RNKeychainManager.resetInternetCredentialsForOptions(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -267,12 +273,12 @@ export async function resetInternetCredentials(options: BaseOptions): Promise<vo
  * ```
  */
 export async function getSupportedBiometryType(): Promise<null | BIOMETRY_TYPE> {
-  try {
-    if (!RNKeychainManager.getSupportedBiometryType) {
-      return Promise.resolve(null);
-    }
+  if (!RNKeychainManager.getSupportedBiometryType) {
+    return null;
+  }
 
-    return RNKeychainManager.getSupportedBiometryType();
+  try {
+    return await RNKeychainManager.getSupportedBiometryType();
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -298,16 +304,14 @@ export async function getSupportedBiometryType(): Promise<null | BIOMETRY_TYPE> 
 export async function requestSharedWebCredentials(): Promise<
   false | SharedWebCredentials
 > {
-  try {
-    if (Platform.OS !== 'ios') {
-      return Promise.reject(
-        new Error(
-          `requestSharedWebCredentials() is not supported on ${Platform.OS} yet`
-        )
-      );
-    }
+  if (Platform.OS !== 'ios') {
+    throw new Error(
+      `requestSharedWebCredentials() is not supported on ${Platform.OS} yet`
+    );
+  }
 
-    return RNKeychainManager.requestSharedWebCredentials();
+  try {
+    return await RNKeychainManager.requestSharedWebCredentials();
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -335,16 +339,14 @@ export async function setSharedWebCredentials(
   username: string,
   password?: string
 ): Promise<void> {
-  try {
-    if (Platform.OS !== 'ios') {
-      return Promise.reject(
-        new Error(
-          `setSharedWebCredentials() is not supported on ${Platform.OS} yet`
-        )
-      );
-    }
+  if (Platform.OS !== 'ios') {
+    throw new Error(
+      `setSharedWebCredentials() is not supported on ${Platform.OS} yet`
+    );
+  }
 
-    return RNKeychainManager.setSharedWebCredentialsForServer(
+  try {
+    return await RNKeychainManager.setSharedWebCredentialsForServer(
       server,
       username,
       password
@@ -372,12 +374,12 @@ export async function setSharedWebCredentials(
 export async function canImplyAuthentication(
   options?: AuthenticationTypeOption
 ): Promise<boolean> {
-  try {
-    if (!RNKeychainManager.canCheckAuthentication) {
-      return Promise.resolve(false);
-    }
+  if (!RNKeychainManager.canCheckAuthentication) {
+    return false;
+  }
 
-    return RNKeychainManager.canCheckAuthentication(options);
+  try {
+    return await RNKeychainManager.canCheckAuthentication(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -401,12 +403,12 @@ export async function canImplyAuthentication(
 export async function getSecurityLevel(
   options?: AccessControlOption
 ): Promise<null | SECURITY_LEVEL> {
-  try {
-    if (!RNKeychainManager.getSecurityLevel) {
-      return Promise.resolve(null);
-    }
+  if (!RNKeychainManager.getSecurityLevel) {
+    return null;
+  }
 
-    return RNKeychainManager.getSecurityLevel(options);
+  try {
+    return await RNKeychainManager.getSecurityLevel(options);
   } catch (err) {
     throw KeychainError.parse(err);
   }
@@ -424,12 +426,12 @@ export async function getSecurityLevel(
  * ```
  */
 export async function isPasscodeAuthAvailable(): Promise<boolean> {
-  try {
-    if (!RNKeychainManager.isPasscodeAuthAvailable) {
-      return Promise.resolve(false);
-    }
+  if (!RNKeychainManager.isPasscodeAuthAvailable) {
+    return false;
+  }
 
-    return RNKeychainManager.isPasscodeAuthAvailable();
+  try {
+    return await RNKeychainManager.isPasscodeAuthAvailable();
   } catch (err) {
     throw KeychainError.parse(err);
   }


### PR DESCRIPTION
This PR adds a custom `KeychainError` error class. It's a follow on from #762 and looks to make it easier for consumers to identify errors from this library and give type safety when responding to various error codes:

```ts
Keychain.getGenericPassword()
  .catch((err) => {
    if (err instanceof KeychainError) {
      switch (error.code) {
        case ERROR_CODE.AUTH_CANCELED:
          console.log('Authentication was canceled');
          break;
        case ERROR_CODE.BIOMETRIC_TIMEOUT:
          console.log('Biometric prompt timed out');
          break;
        case ERROR_CODE.BIOMETRIC_LOCKOUT:
          console.log('Too many failed attempts, biometric authentication locked');
          break;
        default:
          console.log(`Keychain error: ${error.code} - ${error.message}`);
      }
    }
  })
```