### PR TITLE
Fix: Issue with Setting Immutable Key for authenticationPrompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,9 +138,7 @@ export function getAllGenericPasswordServices(
  * console.log('Internet credentials exist:', hasCredentials);
  * ```
  */
-export function hasInternetCredentials(
-  options: BaseOptions
-): Promise<boolean> {
+export function hasInternetCredentials(options: BaseOptions): Promise<boolean> {
   return RNKeychainManager.hasInternetCredentialsForOptions(options);
 }
 

--- a/src/normalizeOptions.ts
+++ b/src/normalizeOptions.ts
@@ -15,6 +15,6 @@ export function normalizeAuthPrompt<T extends SetOptions | GetOptions>(
     authenticationPrompt: {
       ...AUTH_PROMPT_DEFAULTS,
       ...options.authenticationPrompt,
-    }
+    },
   };
 }


### PR DESCRIPTION
This pull request resolves an issue where the key `authenticationPrompt` was attempted to be set with `AUTH_PROMPT_DEFAULTS`.

<img width="400" alt="Screenshot 2025-10-22 at 12 02 55 PM" src="https://github.com/user-attachments/assets/8688cfa0-6426-4357-80f8-a165aa960c8f" />
