### PR TITLE
Fix: Update TypeScript typings for hasInternetCredentials to match native implementations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export function getAllGenericPasswordServices(
  * ```
  */
 export function hasInternetCredentials(
-  options: string | BaseOptions
+  options: BaseOptions
 ): Promise<boolean> {
   return RNKeychainManager.hasInternetCredentialsForOptions(options);
 }


### PR DESCRIPTION
The `hasInternetCredentials` function no longer accepts a string as a parameter.  
Both iOS and Android native implementations now expect an options object with a `server` field.  

This PR updates the TypeScript typings to reflect the correct usage:

iOS native implementation: https://github.com/oblador/react-native-keychain/blob/master/ios/RNKeychainManager/RNKeychainManager.m#L655

Android native implementation: https://github.com/oblador/react-native-keychain/blob/master/android/src/main/java/com/oblador/keychain/KeychainModule.kt#L356
