### PR TITLE
fix: make DataStore a singleton to prevent IllegalStateException on Android 

### DIFF
--- a/android/src/main/java/com/oblador/keychain/DataStorePrefsStorage.kt
+++ b/android/src/main/java/com/oblador/keychain/DataStorePrefsStorage.kt
@@ -8,7 +8,6 @@ import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.facebook.react.bridge.ReactApplicationContext
 import com.oblador.keychain.PrefsStorageBase.Companion.KEYCHAIN_DATA
 import com.oblador.keychain.PrefsStorageBase.Companion.getKeyForCipherStorage
@@ -26,12 +25,26 @@ class DataStorePrefsStorage(
   private val coroutineScope: CoroutineScope,
 ) : PrefsStorageBase {
 
-  private val Context.prefs: DataStore<Preferences> by preferencesDataStore(
-    name = KEYCHAIN_DATA,
-    produceMigrations = ::sharedPreferencesMigration,
-    scope = coroutineScope,
-  )
-  private val prefs: DataStore<Preferences> = reactContext.prefs
+  companion object {
+    @Volatile
+    private var INSTANCE: DataStore<Preferences>? = null
+
+    private fun getDataStore(
+      context: Context,
+      coroutineScope: CoroutineScope,
+      produceMigrations: (Context) -> List<DataMigration<Preferences>>,
+    ): DataStore<Preferences> {
+      return INSTANCE ?: synchronized(this) {
+        INSTANCE ?: androidx.datastore.preferences.core.PreferenceDataStoreFactory.create(
+          produceFile = { context.applicationContext.filesDir.resolve("datastore/$KEYCHAIN_DATA.preferences_pb") },
+          migrations = produceMigrations(context.applicationContext),
+          scope = coroutineScope,
+        ).also { INSTANCE = it }
+      }
+    }
+  }
+
+  private val prefs: DataStore<Preferences> = getDataStore(reactContext, coroutineScope, ::sharedPreferencesMigration)
   private val prefsData: Preferences get() = callSuspendable { prefs.data.first() }
 
   private fun sharedPreferencesMigration(context: Context): List<DataMigration<Preferences>> {


### PR DESCRIPTION
DataStorePrefsStorage creates a new DataStore instance via the preferencesDataStore delegate every time KeychainModule is instantiated. Since Android's DataStore enforces a single-instance-per-file constraint, this was firing the following exception on version 10.0.0 when the module is recreated 

```
 java.lang.IllegalStateException: There are multiple DataStores active for the same file: /data/data/<package>/files/datastore/RN_KEYCHAIN.preferences_pb. 
```

In this PR I replaced the preferencesDataStore property delegate with a companion object singleton using double-checked locking. The DataStore instance is created once via PreferenceDataStoreFactory.create() and reused across all subsequent KeychainModule instantiations. 

This should fix issue #777  and #784.   

I tested this fix on my app running RN 0.81.5 and new architecture. 
