### PR TITLE
fix(android): ensure deterministic cipher selection

### DIFF
--- a/KeychainExample/e2e/testCases/accessControlTest.spec.js
+++ b/KeychainExample/e2e/testCases/accessControlTest.spec.js
@@ -144,6 +144,33 @@ describe('Access Control', () => {
     );
   });
 
+  it(':android:should prefer AES-GCM over RSA for biometric storage', async () => {
+    await expect(element(by.text('Keychain Example'))).toExist();
+    await element(by.id('usernameInput')).typeText('testUsernameCipherPref');
+    await element(by.id('passwordInput')).typeText('testPasswordCipherPref');
+    // Hide keyboard
+    await element(by.text('Keychain Example')).tap();
+
+    // Select biometric access control without specifying storage type
+    await element(by.text('Fingerprint')).tap();
+
+    await expect(element(by.text('Save'))).toBeVisible();
+    await element(by.text('Save')).tap();
+    await enterBiometrics();
+    await expectCredentialsSavedMessage();
+
+    await waitForAuthValidity();
+    await element(by.text('Load')).tap();
+    await enterBiometrics();
+
+    // Verify AES-GCM is selected, not RSA
+    await expectCredentialsLoadedMessage(
+      'testUsernameCipherPref',
+      'testPasswordCipherPref',
+      'KeystoreAESGCM'
+    );
+  });
+
   it('should reset all credentials', async () => {
     await expect(element(by.text('Keychain Example'))).toExist();
     // Hide keyboard

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -149,10 +149,12 @@ class KeychainModule(reactContext: ReactApplicationContext) :
   init {
     prefsStorage = DataStorePrefsStorage(reactContext, coroutineScope)
     // Insertion order is the tie breaker when ciphers have equal capability levels
-    addCipherStorageToMap(CipherStorageKeystoreAesCbc(reactContext))
-    addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, false))
+    // AES-GCM will be preferred over RSA ECB
     addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, true))
     addCipherStorageToMap(CipherStorageKeystoreRsaEcb(reactContext))
+    // AES-GCM will be preferred over AES-CBC
+    addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, false))
+    addCipherStorageToMap(CipherStorageKeystoreAesCbc(reactContext))
   }
 
   // endregion

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -148,6 +148,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
   /** Default constructor. */
   init {
     prefsStorage = DataStorePrefsStorage(reactContext, coroutineScope)
+    // Insertion order is the tie breaker when ciphers have equal capability levels
     addCipherStorageToMap(CipherStorageKeystoreAesCbc(reactContext))
     addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, false))
     addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, true))

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -132,7 +132,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
   // endregion
   // region Members
   /** Name-to-instance lookup map. */
-  private val cipherStorageMap: MutableMap<String, CipherStorage> = HashMap()
+  private val cipherStorageMap: MutableMap<String, CipherStorage> = LinkedHashMap()
 
   /** Shared preferences storage. */
   private val prefsStorage: PrefsStorageBase
@@ -597,7 +597,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       if (!isSupportedApi) continue
 
       // Is the API level better than the one we previously selected (if any)?
-      if (foundCipher != null && capabilityLevel < foundCipher.getCapabilityLevel()) continue
+      if (foundCipher != null && capabilityLevel <= foundCipher.getCapabilityLevel()) continue
 
       // if biometric supported but not configured properly than skip
       if (variant.isAuthSupported() && !isBiometry && !isPasscode) continue


### PR DESCRIPTION
## Summary
- Fix non-deterministic cipher selection when AES-GCM and RSA have equal capability levels
- Use LinkedHashMap to preserve insertion order as tie breaker
- Reorder ciphers so AES-GCM is preferred over RSA for biometric storage

## Problem
Previously, cipher selection used HashMap which has non-deterministic iteration order. When two ciphers had equal capability (AES-GCM and RSA both at 1023), the selected cipher depended on hash bucket ordering, potentially causing inconsistent behavior across devices/installs.

## Solution
- Changed `HashMap` to `LinkedHashMap` to preserve insertion order
- Changed capability comparison from `<` to `<=` so first match wins
- Ordered ciphers by capability descending with preferred ciphers first

## Test plan
- [ ] e2e test added to verify AES-GCM is selected over RSA for biometric access control
