### PR TITLE
fix(ios): evaluate cloudSync boolean value instead of pointer truthiness

### DIFF
--- a/ios/RNKeychainManager/RNKeychainManager.mm
+++ b/ios/RNKeychainManager/RNKeychainManager.mm
@@ -236,7 +236,8 @@ NSString *accessGroupValue(NSDictionary *options)
 
 CFBooleanRef cloudSyncValue(NSDictionary *options)
 {
-  if (options && options[@"cloudSync"]) {
+  id value = options[@"cloudSync"];
+  if (value != nil && [value boolValue]) {
     return kCFBooleanTrue;
   }
   return kCFBooleanFalse;


### PR DESCRIPTION
## Summary
- Fixes bug where `cloudSync: false` was incorrectly treated as `true`
- In Objective-C, `@NO` is a non-nil `NSNumber` object that evaluates as truthy in pointer checks
- This could cause secrets to sync to iCloud even when the caller explicitly disabled cloud sync

## Test plan
- [ ] Call `setGenericPassword` with `{ cloudSync: false }` and verify item is stored with `kSecAttrSynchronizable = false`
- [ ] Call `setGenericPassword` with `{ cloudSync: true }` and verify item is stored with `kSecAttrSynchronizable = true`
- [ ] Call `setGenericPassword` without `cloudSync` option and verify default behavior (no sync)